### PR TITLE
Merlin-p performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 merlin
 example/out_dir/
+example/out_dir*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 merlin
 example/out_dir/
 example/out_dir*
+test/out_dir*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 merlin
 example/out_dir/
-example/out_dir*
-test/out_dir*

--- a/Checkpoint.C
+++ b/Checkpoint.C
@@ -1,0 +1,224 @@
+#include "Checkpoint.H"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <limits>
+#include "Variable.H"
+
+Checkpoint::Checkpoint(const char* inDirName, int inMaxFactorSize)
+{
+    dirName = string(inDirName);
+    maxFactorSize = inMaxFactorSize;
+}
+
+int
+Checkpoint::getIteration()
+{
+    return iter;
+}
+
+bool
+Checkpoint::getHasNotConverged()
+{
+    return hasNotConverged;
+}
+
+double
+Checkpoint::getInitialScore()
+{
+    return initialScore;
+}
+
+unordered_map<string, double>
+Checkpoint::getInitialPLLs()
+{
+    return initialPLLs;
+}
+
+unordered_map<string, int>
+Checkpoint::getVariableStatus()
+{
+    return variableStatus;
+}
+
+unordered_map<string, int>
+Checkpoint::getGeneModuleIDs()
+{
+    return geneModuleIDs;
+}
+
+vector<pair<string, string>>
+Checkpoint::getEdges()
+{
+    return edges;
+}
+
+bool
+Checkpoint::loadCheckpointData()
+{
+    string fileName = dirName + "/checkpoint.txt";
+    ifstream inFile(fileName);
+
+    if (!inFile.is_open()) {
+        cerr << "Error: could not open checkpoint file: " << fileName << endl;
+        return false;
+    }
+
+    string label;
+    inFile >> label >> iter;
+    inFile >> label >> hasNotConverged;
+    inFile.close();
+
+    // Increment by one, because we want to start one iteration past the last completed iteration.
+	iter++;
+
+    bool success = true;
+    success &= loadPLLScore();
+    success &= loadModules();
+    success &= loadEdges();
+    success &= loadLastUpdate();
+    return success;
+}
+
+bool
+Checkpoint::loadPLLScore()
+{
+    string fileName = dirName + "/pll.txt";
+    ifstream inFile(fileName);
+
+	if (!inFile.is_open()) {
+		std::cerr << "Error: could not open checkpoint PLL file: " << fileName << std::endl;
+		return false;
+	}
+
+    double initScore = 0;
+    string varName;
+    double val;
+
+    while (inFile >> varName >> val) {
+        initialPLLs[varName] = val;
+        initScore += val;
+    }
+
+    initialScore = initScore;
+
+    return true;
+}
+
+bool
+Checkpoint::loadModules()
+{
+    string fileName = dirName + "/modules.txt";
+	ifstream inFile(fileName);
+
+	if (!inFile.is_open()) {
+		std::cerr << "Error: could not open checkpoint module file: " << fileName << std::endl;
+		return false;
+	}
+
+    string geneName;
+    int moduleID;
+
+    // Read clustered modules from modules.txt
+    while (inFile >> geneName >> moduleID) {
+        geneModuleIDs[geneName] = moduleID;
+    }
+
+    return true;
+}
+
+bool
+Checkpoint::loadLastUpdate()
+{
+    string fileName = dirName + "/lastUpdate.txt";
+    ifstream inFile(fileName);
+
+	if (!inFile.is_open()) {
+		std::cerr << "Error: could not open checkpoint last update file: " << fileName << std::endl;
+		return false;
+	}
+
+    string varName;
+    int lastUpdateIter;
+
+    while (inFile >> varName >> lastUpdateIter) {
+        variableStatus[varName] = lastUpdateIter;
+    }
+
+    return true;
+}
+
+bool
+Checkpoint::loadEdges()
+{
+    string fileName = dirName + "/prediction_k" + to_string(maxFactorSize) + ".txt";
+    ifstream inFile(fileName);
+
+    if (!inFile.is_open()) {
+		std::cerr << "Error: could not open checkpoint graph file: " << fileName << std::endl;
+		return false;
+	}
+
+    string regName;
+    string targetName;
+    double weight;
+
+    while (inFile >> regName >> targetName >> weight) {
+        edges.push_back(pair<string, string>(regName, targetName));
+    }
+
+    return true;
+}
+
+void
+Checkpoint::writeCheckpointMetadata(int iter, bool notConvergedVal)
+{
+    string fileName = dirName + "/checkpoint.txt";
+    ofstream outFile(fileName);
+    outFile << "iter " << iter << endl;
+    outFile << "notConverged " << notConvergedVal << endl;
+}
+
+void
+Checkpoint::writePLLScore(unordered_map<int, double>* currPLL, const unordered_map<int, Variable*>& varSet)
+{
+	if (currPLL == NULL) {
+		return;
+	}
+
+    string fileName = dirName + "/pll.txt";
+    ofstream outFile(fileName);
+
+	// Force maximum double precision to prevent truncation
+    outFile << std::setprecision(std::numeric_limits<double>::max_digits10);
+
+    for(auto iter = currPLL->begin(); iter != currPLL->end(); iter++) {
+        auto varIter = varSet.find(iter->first);
+        if (varIter == varSet.end()) {
+            continue;
+        }
+        Variable* var = varIter->second;
+        outFile << var->getName() << "\t" << iter->second << endl;
+	}
+}
+
+void
+Checkpoint::writeLastUpdate(unordered_map<string, int>& variableStatus)
+{
+    string fileName = dirName + "/lastUpdate.txt";
+    ofstream outFile(fileName);
+
+    for (auto iter = variableStatus.begin(); iter != variableStatus.end(); iter++) {
+        outFile << iter->first << "\t" << iter->second << endl;
+    }
+}
+
+void
+Checkpoint::doTar()
+{
+    char tarCmd[1024];
+    sprintf(tarCmd, "tar czf %s.tar.gz %s", dirName.c_str(), dirName.c_str());
+    system(tarCmd);
+}

--- a/Checkpoint.H
+++ b/Checkpoint.H
@@ -1,0 +1,58 @@
+#ifndef _CHECKPOINT_
+#define _CHECKPOINT_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace std;
+
+class Variable;
+
+class Checkpoint
+{
+    public:
+        Checkpoint(const char* dirName, int maxFactorSize);
+
+        bool loadCheckpointData();
+
+        int getIteration();
+
+        bool getHasNotConverged();
+
+        double getInitialScore();
+
+        unordered_map<string, double> getInitialPLLs();
+
+        unordered_map<string, int> getVariableStatus();
+
+        unordered_map<string, int> getGeneModuleIDs();
+
+        vector<pair<string, string>> getEdges();
+
+        void writeCheckpointMetadata(int iter, bool notConvergedVal);
+
+        void writePLLScore(unordered_map<int, double>* currPLL, const unordered_map<int, Variable*>& varSet);
+
+        void writeLastUpdate(unordered_map<string, int>& variableStatus);
+
+        void doTar();
+
+    private:
+        bool loadPLLScore();
+        bool loadLastUpdate();
+        bool loadModules();
+        bool loadEdges();
+
+        int iter;
+        bool hasNotConverged;
+        double initialScore;
+        unordered_map<string, double> initialPLLs;
+        unordered_map<string, int> geneModuleIDs;
+        vector<pair<string, string>> edges;
+        unordered_map<string, int> variableStatus;
+        string dirName;
+        int maxFactorSize;
+};
+
+#endif

--- a/Framework.C
+++ b/Framework.C
@@ -212,7 +212,7 @@ main(int argc, char* argv[])
 		cout <<"MERLIN-P GRN Inference " <<  endl
 			<< "-d gene_expression_file " << endl
 			<< "-k maxfactorsize (default size_of_dataset)" << endl
-			<< "-v cross_validation_cnt [BROKEN FOR >1 FOLDS] (default 1)" << endl
+			<< "-v cross_validation_cnt (default 1)" << endl
 			<< "-l restricted_regulator_fname" << endl
 			<< "-p sparsity_prior (default -5)" << endl
 			<< "-r module_prior (default 4)" << endl

--- a/Framework.C
+++ b/Framework.C
@@ -75,7 +75,7 @@ Framework::init(int argc, char** argv)
 			case 'k':
 			{
 				int aSize = atoi(optarg);
-				metaLearner.setMaxFactorSize_Approx(aSize);
+				metaLearner.setMaxFactorSize(aSize);
 				kDefault=false;
 				break;
 			}
@@ -191,7 +191,7 @@ Framework::init(int argc, char** argv)
 	}
 	if(kDefault)
 	{
-		metaLearner.setMaxFactorSize_Approx(300);
+		metaLearner.setMaxFactorSize(300);
 	}
 	if(rDefault)
 	{

--- a/Framework.C
+++ b/Framework.C
@@ -212,7 +212,7 @@ main(int argc, char* argv[])
 		cout <<"MERLIN-P GRN Inference " <<  endl
 			<< "-d gene_expression_file " << endl
 			<< "-k maxfactorsize (default size_of_dataset)" << endl
-			<< "-v cross_validation_cnt (default 1)" << endl
+			<< "-v cross_validation_cnt [BROKEN FOR >1 FOLDS] (default 1)" << endl
 			<< "-l restricted_regulator_fname" << endl
 			<< "-p sparsity_prior (default -5)" << endl
 			<< "-r module_prior (default 4)" << endl

--- a/Framework.C
+++ b/Framework.C
@@ -110,7 +110,12 @@ Framework::init(int argc, char** argv)
 			}
 			case 'q':
 			{
-				metaLearner.setPriorGraph_All(optarg);
+				int status = metaLearner.setPriorGraph_All(optarg);
+				if(status != Error::SUCCESS)
+				{
+					std::cerr << "Failed: " << Error::getErrorString(status) << std::endl;
+					exit(-1); 
+				}
 				break;
 			}
 			case 'c':
@@ -132,7 +137,7 @@ Framework::init(int argc, char** argv)
 			}
 			case 'a':
 			{
-				metaLearner.setShouldLoad(true);
+				metaLearner.setShouldLoadCheckpoint(true);
 				break;
 			}
 			case '?':

--- a/Framework.C
+++ b/Framework.C
@@ -40,7 +40,7 @@ Framework::init(int argc, char** argv)
 	int optret;
 	opterr=1;
 
-	while((optret=getopt(argc,argv,"o:k:d:v:l:p:r:c:h:f:q:"))!=-1)
+	while((optret=getopt(argc,argv,"o:k:d:v:l:p:r:c:h:f:q:a"))!=-1)
 	{
 		switch(optret)
 		{
@@ -130,6 +130,11 @@ Framework::init(int argc, char** argv)
 				metaLearner.setSpecificFold(atoi(optarg));
 				break;
 			}
+			case 'a':
+			{
+				metaLearner.setShouldLoad(true);
+				break;
+			}
 			case '?':
 			{
 				cerr << "Option error " << optopt << endl;
@@ -215,7 +220,8 @@ main(int argc, char* argv[])
 			<< "-o outputdirectory" << endl
 			<< "-c moduleassignment (default random_partitioning) "<< endl
 			<< "-h hierarchical_clustering_threshold (default 0.6)"<< endl
-			<< "-f specificfold_torun (default is -1)" << endl ;
+			<< "-f specificfold_torun (default is -1)" << endl 
+			<< "-a load_checkpoint (default is false)" << endl ;
 		return 0;
 	}
 	Framework fw;

--- a/HierarchicalCluster.C
+++ b/HierarchicalCluster.C
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <sys/timeb.h>
-#include <sys/time.h>
-#include <time.h>
 
 #include "Error.H"
 #include "Matrix.H"
@@ -18,8 +15,7 @@
 HierarchicalClusterNode*
 HierarchicalCluster::getNode(string nodeName)
 {
-	if(nodeSet.find(nodeName)==nodeSet.end())
-	{
+	if(nodeSet.find(nodeName) == nodeSet.end()) {
 		return nullptr;
 	}
 	return nodeSet[nodeName];
@@ -31,267 +27,210 @@ HierarchicalCluster::addNode(HierarchicalClusterNode* node)
 	nodeSet[node->nodeName] = node;
 }
 
-int
-HierarchicalCluster::cluster(map<int,map<string,int>*>& modules, double threshold, Matrix* correlationDistances)
+void
+HierarchicalCluster::cluster(map<int,map<string,int>*>& modules, double threshold, Matrix* correlationDistances, Matrix* sharedParentDistances)
 {
-	// currNodeSet holds the subset of nodes in the dendrogram that currently have no parent.
-	map<int,HierarchicalClusterNode*> currNodeSet;
-
-	// Load leaves into currNodeSet
-	for(map<string,HierarchicalClusterNode*>::iterator nIter=nodeSet.begin();nIter!=nodeSet.end();nIter++)
-	{
-		int nextNodeIndex = currNodeSet.size();
-		currNodeSet[nextNodeIndex]=nIter->second;
-		nIter->second->id=nextNodeIndex;
-	}
-
 	//The total number of nodes that can be there in a hierarchical cluster is 2n-1
-	int treenodecnt = (nodeSet.size()*2) - 1;
+	int treeNodeCnt = (nodeSet.size() * 2) - 1;
 
 	// Instantiate default distances
-	distvalues = new double*[treenodecnt];
-	for (int i = 0; i < treenodecnt; i++)
-	{
-		distvalues[i] = new double[treenodecnt];
-		for (int j = 0; j < treenodecnt; j++)
-		{
-			distvalues[i][j] = -1000;
+	distValues = new double*[treeNodeCnt];
+	for (int i = 0; i < treeNodeCnt; i++) {
+		distValues[i] = new double[treeNodeCnt];
+		for (int j = 0; j < treeNodeCnt; j++) {
+			distValues[i][j] = -1000;
 		}
+	}
+
+	// Load the nodes into a vector for fast iteration.
+	vector<HierarchicalClusterNode*> allNodes;
+	for(auto iter = nodeSet.begin(); iter != nodeSet.end(); iter++) {
+		int nextNodeIndex = allNodes.size();
+		allNodes.push_back(iter->second);
+		iter->second->id = nextNodeIndex;
 	}
 
 	// Populate distances between the leaf nodes.
-	vector<Pair*> pairs = estimatePairwiseDist(currNodeSet, correlationDistances, threshold);
+	vector<Pair> pairs = estimatePairwiseDist(allNodes, correlationDistances, sharedParentDistances, threshold);
 
-	priority_queue<Pair*, vector<Pair*>, ComparePair> pairQueue(pairs.begin(), pairs.end());
+	priority_queue<Pair, vector<Pair>, ComparePair> pairQueue(pairs.begin(), pairs.end());
+
+	unordered_map<int, HierarchicalClusterNode*> unmergedNodes;
+	for (int i = 0; i < allNodes.size(); i++) {
+		unmergedNodes[i] = allNodes[i];
+	}
 
 	vector<HierarchicalClusterNode*> internalNodes;
+	int nextNodeID = unmergedNodes.size();
 
 	// Merge pairs until threshold distance is reached.
-	int nextNodeID = currNodeSet.size();
-	while(currNodeSet.size()>1)
-	{
-		Pair *nextPair = getNextPair(pairQueue);
-		if (nextPair == nullptr)
-		{
+	while(unmergedNodes.size() > 1) {
+
+		Pair nextPair;
+		if (!getNextPair(pairQueue, nextPair)) {
 			break;
 		}
 
-		HierarchicalClusterNode *newNode = createMergeNode(nextPair, currNodeSet, nextNodeID);
+		HierarchicalClusterNode *newNode = createMergeNode(nextPair, unmergedNodes, nextNodeID);
 		internalNodes.push_back(newNode);
-		addMergeNode(newNode, currNodeSet, pairs, pairQueue, threshold);
+		addMergeNode(newNode, unmergedNodes, pairs, pairQueue, threshold);
 
 		nextNodeID += 1;
 	}
 
-	// Populates modules with the clustering represented by currNodeSet
-	generateModules(currNodeSet, modules);
+	// Populates modules with the clustering represented by unmergedNodes
+	generateModules(unmergedNodes, modules);
 
 	// Reset parent to null on all the cached leaf nodes.
-	for(map<string,HierarchicalClusterNode*>::iterator aIter=nodeSet.begin();aIter!=nodeSet.end();aIter++)
-	{
+	for(map<string, HierarchicalClusterNode*>::iterator aIter = nodeSet.begin(); aIter != nodeSet.end(); aIter++) {
 		aIter->second->parent = nullptr;
 	}
 
 	// Clean up all the data
-	for (vector<HierarchicalClusterNode*>::iterator it = internalNodes.begin(); it != internalNodes.end(); it++)
-	{
+	for (vector<HierarchicalClusterNode*>::iterator it = internalNodes.begin(); it != internalNodes.end(); it++) {
 		delete *it;
 	}
-	for (int i = 0; i < treenodecnt; i++)
-	{
-		delete [] distvalues[i];
+	for (int i = 0; i < treeNodeCnt; i++) {
+		delete [] distValues[i];
 	}
-	delete [] distvalues;
-	for (int i = 0; i < pairs.size(); i++)
-	{
-		delete pairs[i];
-	}
-
-	return 0;
+	delete [] distValues;
 }
 
-vector<HierarchicalCluster::Pair*>
-HierarchicalCluster::estimatePairwiseDist(map<int,HierarchicalClusterNode*>& currNodeSet, Matrix* correlationDistances, double threshold)
+vector<HierarchicalCluster::Pair>
+HierarchicalCluster::estimatePairwiseDist(vector<HierarchicalClusterNode*>& nodes, Matrix* correlationDistances, Matrix* sharedParentDistances, double threshold)
 {
-	vector<double> denoms(currNodeSet.size(), 0);
+	vector<Pair> pairs;
+	for (int i = 0; i < nodes.size(); i++) {
 
-	for (int i = 0; i < currNodeSet.size(); i++)
-	{
-		double denom = 0;
-		HierarchicalClusterNode* node = currNodeSet[i];
-		for(map<int,double>::iterator iter = node->attrib.begin(); iter != node->attrib.end(); iter++)
-		{
-			denom += fabs(iter->second);
-		}
-		denoms[i] = denom;
-	}
+		HierarchicalClusterNode* hcNode1 = nodes[i];
 
-	vector<Pair*> pairs;
+		for(int j = i + 1; j < nodes.size(); j++) {
 
-	for (int i = 0; i < currNodeSet.size(); i++)
-	{
-		HierarchicalClusterNode* hcNode1 = currNodeSet[i];
-		double den1 = denoms[i];
-
-		for(int j = i + 1; j < currNodeSet.size(); j++)
-		{
-			HierarchicalClusterNode* hcNode2 = currNodeSet[j];
-			double den2 = denoms[j];
+			HierarchicalClusterNode* hcNode2 = nodes[j];
 
 			double ccdist = correlationDistances->getValue(hcNode1->varID, hcNode2->varID);
+			double rdist = sharedParentDistances->getValue(hcNode1->varID, hcNode2->varID);
 
-			double sharedSign = 0;
-			for(map<int,double>::iterator aIter = hcNode1->attrib.begin(); aIter != hcNode1->attrib.end(); aIter++)
-			{
-				map<int, double>::iterator bIter = hcNode2->attrib.find(aIter->first);
-				if(bIter == hcNode2->attrib.end())
-				{
-					continue;
-				}
-
-				double weight1 = aIter->second;
-				double weight2 = bIter->second;
-				if(weight1 * weight2 >= 0)
-				{
-					sharedSign += (fabs(weight1) + fabs(weight2)) * 0.5;
-				}
-			}
-
-			double rdist = 1 - sharedSign / (den1 + den2 - sharedSign);
 			double dist = (ccdist + rdist) / 2;
-			distvalues[i][j] = dist;
-			distvalues[j][i] = dist;
+			distValues[i][j] = dist;
+			distValues[j][i] = dist;
 
-			if (dist >= threshold)
-			{
+			if (dist >= threshold) {
 				continue;
 			}
 
-			Pair* p = new Pair;
-			p->node1 = hcNode1;
-			p->node2 = hcNode2;
-			p->value = dist;
+			Pair p;
+			p.node1 = hcNode1;
+			p.node2 = hcNode2;
+			p.value = dist;
 			pairs.push_back(p);
 		}
 	}
-
 	return pairs;
 }
 
-HierarchicalCluster::Pair*
-HierarchicalCluster::getNextPair(priority_queue<Pair*, vector<Pair*>, ComparePair>& pairQueue)
+bool
+HierarchicalCluster::getNextPair(priority_queue<Pair, vector<Pair>, ComparePair>& pairQueue, Pair& nextPair)
 {
 	//Keep popping until we reach a pair whose both members have not been visited
-	while(!pairQueue.empty())
-	{
-		HierarchicalCluster::Pair* pair = pairQueue.top();
-
-		if (pair->node1->parent == nullptr && pair->node2->parent == nullptr)
-		{
-			return pair;
-		}
-
+	while(!pairQueue.empty()) {
+		Pair pair = pairQueue.top();
 		pairQueue.pop();
+
+		if (pair.node1->parent == nullptr && pair.node2->parent == nullptr) {
+			nextPair = pair;
+			return true;
+		}
 	}
 
 	// There was no unvisited node, so we are done merging.
-	return nullptr;
+	return false;
 }
 
 HierarchicalClusterNode*
-HierarchicalCluster::createMergeNode(Pair *pair, map<int,HierarchicalClusterNode*>& currNodeSet, int nextNodeID)
+HierarchicalCluster::createMergeNode(Pair& pair, unordered_map<int,HierarchicalClusterNode*>& unmergedNodes, int nextNodeID)
 {
-	HierarchicalClusterNode* c1=pair->node1;
-	HierarchicalClusterNode* c2=pair->node2;
+	HierarchicalClusterNode* c1 = pair.node1;
+	HierarchicalClusterNode* c2 = pair.node2;
 
 	// Create a new node for the merged pair
-	HierarchicalClusterNode* c12=new HierarchicalClusterNode;
+	HierarchicalClusterNode* c12 = new HierarchicalClusterNode;
 	c12->id = nextNodeID;
-	c12->left=c1;
-	c12->right=c2;
-	c12->size=c1->size+c2->size;
+	c12->left = c1;
+	c12->right = c2;
+	c12->size = c1->size + c2->size;
 
-	c1->parent=c12;
-	c2->parent=c12;
+	c1->parent = c12;
+	c2->parent = c12;
 
-	// Remove child nodes from the currNodeSet
-	currNodeSet.erase(c1->id);
-	currNodeSet.erase(c2->id);
+	// Remove the merged nodes from unmergedNodes
+	unmergedNodes.erase(c1->id);
+	unmergedNodes.erase(c2->id);
 
 	return c12;
 }
 
 void
-HierarchicalCluster::addMergeNode(HierarchicalClusterNode* node, map<int,HierarchicalClusterNode*>& currNodeSet, vector<Pair*>& pairs, priority_queue<Pair*, vector<Pair*>, ComparePair>& pairQueue, double threshold)
+HierarchicalCluster::addMergeNode(HierarchicalClusterNode* node, unordered_map<int, HierarchicalClusterNode*>& unmergedNodes, vector<Pair>& pairs, priority_queue<Pair, vector<Pair>, ComparePair>& pairQueue, double threshold)
 {
-	HierarchicalClusterNode* c1=node->left;
-	HierarchicalClusterNode* c2=node->right;
+	HierarchicalClusterNode* c1 = node->left;
+	HierarchicalClusterNode* c2 = node->right;
 
-	double* dist_n1=distvalues[c1->id];
-	double* dist_n2=distvalues[c2->id];
-	double* dist_n12=distvalues[node->id];
+	double* dist_n1 = distValues[c1->id];
+	double* dist_n2 = distValues[c2->id];
+	double* dist_n12 = distValues[node->id];
 
 	// For every other node, set the distance to the new node and create a new pair.
-	for(map<int,HierarchicalClusterNode*>::iterator nIter=currNodeSet.begin();nIter!=currNodeSet.end();nIter++)
-	{
-		double d1=dist_n1[nIter->first];
-		double d2=dist_n2[nIter->first];
-		double dkm_rdist=((c1->size*d1) + (c2->size*d2))/((double)(c1->size + c2->size));
-		double dist=dkm_rdist;
-		dist_n12[nIter->first]=dist;
-		double* dist_other=distvalues[nIter->first];
-		dist_other[node->id]=dist;
+	for(auto nIter = unmergedNodes.begin(); nIter != unmergedNodes.end(); nIter++) {
 
-		if (dist >= threshold)
-		{
+		double d1 = dist_n1[nIter->first];
+		double d2 = dist_n2[nIter->first];
+		double dkm_rdist = ((c1->size * d1) + (c2->size * d2))/((double)(c1->size + c2->size));
+		double dist = dkm_rdist;
+		dist_n12[nIter->first] = dist;
+		double* dist_other = distValues[nIter->first];
+		dist_other[node->id] = dist;
+
+		if (dist >= threshold) {
 			continue;
 		}
 
-		Pair* newPair=new Pair;
-		newPair->value=dist;
-		newPair->node1=nIter->second;
-		newPair->node2=node;
+		Pair newPair;
+		newPair.value = dist;
+		newPair.node1 = nIter->second;
+		newPair.node2 = node;
 		pairQueue.push(newPair);
 		pairs.push_back(newPair);
 	}
 
-	currNodeSet[node->id]=node;
+	unmergedNodes[node->id] = node;
 }
 
-int
-HierarchicalCluster::generateModules(map<int,HierarchicalClusterNode*>& currNodeSet,map<int,map<string,int>*>& modules)
+void
+HierarchicalCluster::generateModules(unordered_map<int, HierarchicalClusterNode*>& unmergedNodes, map<int, map<string, int>*>& modules)
 {
-	int moduleCnt=modules.size();
-	for(map<int,HierarchicalClusterNode*>::iterator cIter=currNodeSet.begin();cIter!=currNodeSet.end();cIter++)
-	{
-		HierarchicalClusterNode* node=cIter->second;
-		map<string,int>* moduleMembers=new map<string,int>;
-		modules[moduleCnt]=moduleMembers;
-		populateMembers(moduleMembers,node);
-		// cout <<"Module " << moduleCnt << " size: "<< moduleMembers->size() << endl;
-		moduleCnt=moduleCnt+1;
+	int moduleCnt = modules.size();
+	for(auto cIter = unmergedNodes.begin(); cIter != unmergedNodes.end(); cIter++) {
+		HierarchicalClusterNode* node = cIter->second;
+		map<string,int>* moduleMembers = new map<string,int>;
+		modules[moduleCnt] = moduleMembers;
+		populateMembers(moduleMembers, node);
+		moduleCnt += 1;
 	}
 	cout <<"   Number of non-singleton modules: " << moduleCnt << endl;
-	return 0;
 }
 
-int
-HierarchicalCluster::populateMembers(map<string,int>* members,HierarchicalClusterNode* node)
+void
+HierarchicalCluster::populateMembers(map<string,int>* members, HierarchicalClusterNode* node)
 {
-	if(node->left==NULL && node->right==NULL)
-	{
-		(*members)[node->nodeName]=0;
-	}
-	else
-	{
-		if(node->left!=NULL)
-		{
-			populateMembers(members,node->left);
+	if(node->left == NULL && node->right == NULL) {
+		(*members)[node->nodeName] = 0;
+	} else {
+		if (node->left != NULL) {
+			populateMembers(members, node->left);
 		}
-		if(node->right!=NULL)
-		{
-			populateMembers(members,node->right);
+		if (node->right != NULL) {
+			populateMembers(members, node->right);
 		}
 	}
-	return 0;
 }

--- a/HierarchicalCluster.H
+++ b/HierarchicalCluster.H
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <queue>
+#include <unordered_map>
 
 using namespace std;
 
@@ -15,8 +16,10 @@ class HierarchicalCluster
 {
 	public:
 		HierarchicalClusterNode* getNode(string nodeName);
+
 		void addNode(HierarchicalClusterNode* node);
-		int cluster(map<int,map<string,int>*>& modules, double threshold, Matrix* correlationDistances);
+
+		void cluster(map<int, map<string, int>*>& modules, double threshold, Matrix* correlationDistances, Matrix* sharedParentDistances);
 
 	private:
 		struct Pair
@@ -29,21 +32,21 @@ class HierarchicalCluster
 		class ComparePair
 		{
 			public:
-			bool operator() (Pair* p1, Pair* p2)
+			bool operator() (Pair& p1, Pair& p2)
 			{
-				return p1->value > p2->value;
+				return p1.value > p2.value;
 			}
 		};
 
-		vector<Pair*> estimatePairwiseDist(map<int,HierarchicalClusterNode*>& currNodeSet, Matrix* correlation, double threshold);
-		void addMergeNode(HierarchicalClusterNode* node, map<int,HierarchicalClusterNode*>& currNodeSet, vector<Pair*>& pairs, priority_queue<Pair*, vector<Pair*>, ComparePair>& pairQueue, double threshold);
+		vector<Pair> estimatePairwiseDist(vector<HierarchicalClusterNode*>& nodes, Matrix* correlation, Matrix* sharedParentDistances, double threshold);
+		void addMergeNode(HierarchicalClusterNode* node, unordered_map<int,HierarchicalClusterNode*>& unmergedNodes, vector<Pair>& pairs, priority_queue<Pair, vector<Pair>, ComparePair>& pairQueue, double threshold);
 
-		static HierarchicalClusterNode* createMergeNode(Pair *pair, map<int,HierarchicalClusterNode*>& currNodeSet, int nextNodeID);
-		static Pair* getNextPair(priority_queue<Pair*, vector<Pair*>, ComparePair>& pairQueue);
-		static int generateModules(map<int,HierarchicalClusterNode*>& currNodeSet,map<int,map<string,int>*>& modules);
-		static int populateMembers(map<string,int>* members,HierarchicalClusterNode* node);
+		static HierarchicalClusterNode* createMergeNode(Pair& pair, unordered_map<int,HierarchicalClusterNode*>& unmergedNodes, int nextNodeID);
+		static bool getNextPair(priority_queue<Pair, vector<Pair>, ComparePair>& pairQueue, Pair& nextPair);
+		static void generateModules(unordered_map<int, HierarchicalClusterNode*>& unmergedNodes, map<int, map<string, int>*>& modules);
+		static void populateMembers(map<string, int>* members, HierarchicalClusterNode* node);
 
-		double** distvalues;
-		map<string,HierarchicalClusterNode*> nodeSet;
+		double** distValues;
+		map<string, HierarchicalClusterNode*> nodeSet;
 };
 #endif

--- a/HierarchicalClusterNode.H
+++ b/HierarchicalClusterNode.H
@@ -1,9 +1,7 @@
 #ifndef _HIERARCHICAL_CLUSTER_NODE
 #define _HIERARCHICAL_CLUSTER_NODE
 
-#include <map>
 #include <string>
-#include <vector>
 
 using namespace std;
 
@@ -12,8 +10,6 @@ class HierarchicalClusterNode
 	public:
 		HierarchicalClusterNode();
 
-		map<int,double> attrib;
-		vector<double> expr;
 		HierarchicalClusterNode* left;
 		HierarchicalClusterNode* right;
 		HierarchicalClusterNode* parent;

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 LFLAG = -lgsl -lgslcblas 
-SRC = Framework.C MetaLearner.C MetaMove.C common/Error.C common/EvidenceManager.C common/Potential.C common/SlimFactor.C common/VariableManager.C common/Evidence.C common/FactorGraph.C common/Matrix.C common/PotentialManager.C common/Variable.C HierarchicalCluster.C HierarchicalClusterNode.C HyperGeomPval.C
+SRC = Framework.C MetaLearner.C MetaMove.C common/Error.C common/EvidenceManager.C common/Potential.C common/SlimFactor.C common/VariableManager.C common/Evidence.C common/FactorGraph.C common/Matrix.C common/PotentialManager.C common/Variable.C HierarchicalCluster.C HierarchicalClusterNode.C HyperGeomPval.C Checkpoint.C
 LIBPATH=gsl_lib/
 INCLPATH1=gsl_incl/
 INCLPATH2=common

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -28,7 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
-	shouldLoad = false; //********
+	shouldLoad = false; // checkpointing
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -45,7 +45,7 @@ MetaLearner::~MetaLearner()
 }
 
 int
-MetaLearner::setShouldLoad(bool shouldLoadVal) //********
+MetaLearner::setShouldLoad(bool shouldLoadVal) // checkpointing
 {
 	shouldLoad = shouldLoadVal;
 	return 0;
@@ -477,8 +477,6 @@ MetaLearner::doCrossValidation(int foldCnt)
 
 		getPredictionError_CrossValid(f);
 		clearFoldSpecData();
-		// for multiple folds there is leakage: at the start of a new fold, moduleGeneSet is never reset and prev fold's modules are used in initPhysicalDegree
-		// for multiple folds there is leakage: at the start of a new fold, geneModuleID is never reset prev fold's modules are used in getNextMove, makeMove, getModuleContribLogistic
 	}
 	gsl_rng_free(r);
 
@@ -514,7 +512,7 @@ MetaLearner::start(int f)
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad && loadedMetadata) //********
+	if (shouldLoad && loadedMetadata) // checkpointing
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -583,10 +581,10 @@ MetaLearner::start(int f)
 		scorePremodule=currGlobalScore;
 		dumpAllGraphs(maxFactorSizeApprox,f);
 
-		writeCheckpointMetadata(iter, rseed, notConverged); //********
-		writePLLScore(); //********
-		writeLastUpdate(); //********
-		doTar(); //********
+		writeCheckpointMetadata(iter, rseed, notConverged); // checkpointing
+		writePLLScore(); // checkpointing
+		writeLastUpdate(); // checkpointing
+		doTar(); // checkpointing
 
 		iter++;
 	}
@@ -691,7 +689,7 @@ MetaLearner::initEdgeSet()
 			{
 				initPrior=1-1e-6;
 			}
-			edgePresenceProb[edgeKey]=initPrior; // this is never used...
+			edgePresenceProb[edgeKey]=initPrior;
 			if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
 			{
 				varNeighborhoodPrior[vIter->first]=log(1-initPrior);
@@ -1499,7 +1497,7 @@ MetaLearner::initCorrelationDistances()
 }
 
 
-// ******** checkpointing additions
+// checkpointing additions
 
 int
 MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <iomanip>
 #include <limits>
+#include <algorithm>
 
 #include "Error.H"
 #include "Variable.H"
@@ -37,10 +38,7 @@ MetaLearner::MetaLearner()
 	factorGraph=nullptr;
 	currPLL=nullptr;
 	correlationDistances=nullptr;
-}
-
-MetaLearner::~MetaLearner()
-{
+	sharedParentDistances=nullptr;
 }
 
 void
@@ -61,17 +59,15 @@ MetaLearner::setBeta1(double aval)
 	beta1=aval;
 }
 
-int
+void
 MetaLearner::initEdgePriorMeta_All()
 {
-	for(map<string,map<string,map<string,double>*>*>::iterator gIter=priorgraphmap.begin();gIter!=priorgraphmap.end();gIter++)
-	{
-		map<string,map<string,double>*>* priorgraph = gIter->second;
-		map<int,INTDBLMAP*>* edgeprior = new map<int,INTDBLMAP*>();
-		edgepriormap[gIter->first] = edgeprior;
+	for(map<string, map<string, map<string, double>*>*>::iterator gIter = priorGraphMap.begin(); gIter != priorGraphMap.end(); gIter++) {
+		map<string, map<string, double>*>* priorgraph = gIter->second;
+		unordered_map<int, unordered_map<int, double>*>* edgeprior = new unordered_map<int, unordered_map<int, double>*>();
+		edgePriorMap[gIter->first] = edgeprior;
 		initEdgePriorMeta(gIter->first,*priorgraph,*edgeprior);
 	}
-	return 0;
 }
 
 int
@@ -114,7 +110,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
 			tok=strtok(NULL,"\t");
 			tokCnt++;
 		}
-		betamap[gname] = gbeta;
+		betaMap[gname] = gbeta;
 		map<string,map<string,double>*>* priorGraph = new map<string,map<string,double>*>();
 		int status = setPriorGraph(fname.c_str(), *priorGraph);
 		if(status != Error::SUCCESS)
@@ -123,7 +119,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
 			delete priorGraph;
 			return status;
 		}
-		priorgraphmap[gname] = priorGraph;
+		priorGraphMap[gname] = priorGraph;
 	}
 	inFile.close();
 	return Error::SUCCESS;
@@ -187,7 +183,6 @@ MetaLearner::setClusteringThreshold(double aVal)
 {
 	clusterThreshold=aVal;
 }
-
 
 void
 MetaLearner::setSpecificFold(int fid)
@@ -257,7 +252,7 @@ MetaLearner::setRandom(bool flag)
 	random=flag;
 }
 
-int
+void
 MetaLearner::readModuleMembership(const char* aFName)
 {
 	ifstream inFile(aFName);
@@ -300,15 +295,13 @@ MetaLearner::readModuleMembership(const char* aFName)
 		geneModuleID[geneName]=moduleID;
 	}
 	inFile.close();
-
-	return 0;
 }
 
-int
+void
 MetaLearner::setDefaultModuleMembership()
 {
-	VSET& varSet=varManager->getVariableSet();
-	int vCnt=varSet.size();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	int vCnt = varSet.size();
 	int moduleCnt=(int) sqrt(vCnt/2);
 	if(moduleCnt>30)
 	{
@@ -354,17 +347,15 @@ MetaLearner::setDefaultModuleMembership()
 	}
 	randIndex.clear();
 	usedInit.clear();
-	return 0;
 }
 
 int
-MetaLearner::initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePriors)
+MetaLearner::initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, unordered_map<int, unordered_map<int, double>*>& edgePriors)
 {
-	VSET& varSet=varManager->getVariableSet();
 	cout << "Initializing prior: \"" << priorName << "\" " << endl;
 	for(map<string,int>::iterator rIter=restrictedVarList.begin();rIter!=restrictedVarList.end();rIter++)
 	{
-		int regId=varManager->getVarID(rIter->first.c_str());
+		int regId=varManager->getVarID(rIter->first);
 		if(regId==-1)
 		{
 			continue;
@@ -377,44 +368,34 @@ MetaLearner::initEdgePriorMeta(const string& priorName, map<string,map<string,do
 		map<string,double>* tgtSet=graph[rIter->first];
 		for(map<string,double>::iterator vIter=tgtSet->begin();vIter!=tgtSet->end();vIter++)
 		{
-			INTDBLMAP* edgePriorGene=NULL;
-			int tgtId=varManager->getVarID(vIter->first.c_str());
-			if(tgtId==-1)
-			{
+			unordered_map<int, double>* edgePriorGene = NULL;
+			int tgtId = varManager->getVarID(vIter->first);
+			if (tgtId == -1) {
 				continue;
 			}
-			if(edgePriors.find(tgtId)==edgePriors.end())
-			{
-				edgePriorGene=new INTDBLMAP;
-				edgePriors[tgtId]=edgePriorGene;
-			}
-			else
-			{
-				edgePriorGene=edgePriors[tgtId];
+			if (edgePriors.find(tgtId) == edgePriors.end()) {
+				edgePriorGene = new unordered_map<int, double>;
+				edgePriors[tgtId] = edgePriorGene;
+			} else {
+				edgePriorGene = edgePriors[tgtId];
 			}
 			double ewt=fabs(vIter->second);
-			if(edgePriorGene->find(regId)==edgePriorGene->end())
-			{
-				//(*edgePriorGene)[regId]=vIter->second;
-				(*edgePriorGene)[regId]=ewt;
-			}
-			else
-			{
-				//(*edgePriorGene)[regId]=(*edgePriorGene)[regId]+vIter->second;
-				(*edgePriorGene)[regId]=(*edgePriorGene)[regId]+ewt;
+			if (edgePriorGene->find(regId) == edgePriorGene->end()) {
+				(*edgePriorGene)[regId] = ewt;
+			} else {
+				(*edgePriorGene)[regId] += ewt;
 			}
 			tfhit++;
 		}
-		// cout << " Regulator "<< rIter->first << " has " << tfhit << " targets" << endl;
 	}
 
 	return 0;
 }
 
-int
+void
 MetaLearner::doCrossValidation(int foldCnt)
 {
-	gsl_rng* r=gsl_rng_alloc(gsl_rng_default);
+	gsl_rng* r = gsl_rng_alloc(gsl_rng_default);
 
 	evidenceManager->setFoldCnt(foldCnt);
 	evidenceManager->splitData(0);
@@ -424,25 +405,23 @@ MetaLearner::doCrossValidation(int foldCnt)
 	//The first key is for the fold number
 	//For each fold we have a trained model. For each trained model we have the likelihood on
 	//all the test sets, including the self test.
-	int foldBegin=0;
-	int foldEnd=foldCnt;
-	if(specificFold>-1)
-	{
-		foldBegin=specificFold;
-		foldEnd=specificFold+1;
+	int foldBegin = 0;
+	int foldEnd = foldCnt;
+	if(specificFold > -1) {
+		foldBegin = specificFold;
+		foldEnd = specificFold + 1;
 	}
-	for(int f=foldBegin;f<foldEnd;f++)
-	{
+
+	for(int f = foldBegin; f < foldEnd; f++) {
 		evidenceManager->splitData(f);
-		if(random)
-		{
+		if(random) {
 			evidenceManager->randomizeEvidence(r, varManager);
 		}
 
 		vector<int> regIDs;
 		for (map<string,int>::iterator iter = restrictedVarList.begin(); iter != restrictedVarList.end(); iter++)
 		{
-			int regID = varManager->getVarID(iter->first.c_str());
+			int regID = varManager->getVarID(iter->first);
 			regIDs.push_back(regID);
 		}
 
@@ -451,7 +430,7 @@ MetaLearner::doCrossValidation(int foldCnt)
 		factorGraph = new FactorGraph(varManager);
 
 		char outputDir[1024];
-		sprintf(outputDir,"%s/fold%d",outputDirName,f);
+		sprintf(outputDir,"%s/fold%d", outputDirName, f);
 		char foldOutputDirCmd[1024];
 		sprintf(foldOutputDirCmd,"mkdir -p %s",outputDir);
 		system(foldOutputDirCmd);
@@ -463,16 +442,13 @@ MetaLearner::doCrossValidation(int foldCnt)
 		clearFoldSpecData();
 	}
 	gsl_rng_free(r);
-
-	return 0;
 }
 
-int
-MetaLearner::start(int f)
+void
+MetaLearner::start(int currFold)
 {
-	currFold=f;
-	sprintf(foldoutDirName,"%s/fold%d",outputDirName,f);
-	int maxNumRegs = maxFactorSizeApprox-1; // max num of regulators a gene can have
+	sprintf(foldoutDirName, "%s/fold%d", outputDirName, currFold);
+	int maxNumRegs = maxFactorSizeApprox - 1;
 
 	int iter = 0;
 	bool notConverged=true;
@@ -486,103 +462,104 @@ MetaLearner::start(int f)
 		}
 	}
 
-	initEdgePriorMeta_All(); // populates edgepriormap
-	initEdgeSet(); // populates edgeMap, edgePresenceProb (unused), varNeighborhoodPrior, potentials
+	initEdgePriorMeta_All(); // populates edgePriorMap
+	initEdgeSet(); // populates edgeMap, edgePresenceProb, varNeighborhoodPrior, potentials
 
-	VSET& varSet=varManager->getVariableSet();
-	double currGlobalScore=0;
-	if (shouldLoadCheckpoint && loadedMetadata)
-	{
+	double currGlobalScore = 0;
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
+	if (shouldLoadCheckpoint && loadedMetadata) {
+
+		// overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
 		cout << "Read modules..." << endl;
-		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
+		readCheckpointModuleMembership();
 
+		// populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
 		cout << "Read networks..." << endl;
-		populateGraphsFromFile(maxFactorSizeApprox); // populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
+		populateGraphsFromFile(maxFactorSizeApprox);
 
 		currGlobalScore = loadInitPLLScore(); 
-		loadLastUpdate(); // populates variableStatus
-	}
-	else
-	{
-		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
 
-		for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
-		{
-			variableStatus[vIter->second->getName()] = 0;
+		// populates variableStatus
+		loadLastUpdate(); 
+
+	} else {
+		// populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
+		initPhysicalDegree();
+
+		for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
+			Variable *var = vIter->second;
+			variableStatus[var->getName()] = 0;
 		}
+
 		currGlobalScore = getInitPLLScore();
 	}
 
-	while(notConverged && iter<50)
-	{
+	while(notConverged && iter<50) {
 		cout << "Beginning regulator identification of iter " << iter << endl;
-		int subiter=0;
-		double scorePremodule=currGlobalScore;
-		while(subiter<varSet.size())
-		{
-			int vID=subiter;
-			Variable* v=varSet[vID];
+
+		int varID = 0;
+		double scorePremodule = currGlobalScore;
+
+		while(varID < varSet.size()) {
+
+			Variable* v = varSet[varID];
 
 			// If 5 iterations have passed without finding a score improving parent, then skip.
 			int lastiter = variableStatus[v->getName()];
-			if((iter - lastiter) >= 5)
-			{
-				// cout <<"   Skipping gene " << v->getName() << "; no parents added in last 5 iters." << endl;
-				subiter++;
+			if((iter - lastiter) >= 5) {
+				cout <<"   Skipping gene " << v->getName() << "; no parents added in last 5 iters." << endl;
+				varID++;
 				continue;
 			}
 
-			MetaMove* nextMove = getNextMove(maxNumRegs, vID);
-			if (nextMove == nullptr)
-			{
-				subiter++;
+			MetaMove nextMove;
+			if (!getNextMove(maxNumRegs, varID, nextMove)) {
+				cout <<"   No move found " << v->getName() << endl;
+				varID++;
 				continue;
 			}
 
 			makeMove(nextMove, iter);
-			delete nextMove;
 
-			currGlobalScore=getPLLScore();
+			currGlobalScore = getPLLScore();
 
-			subiter++;
+			varID++;
 		}
 		cout << "   Finished identifying regulators with score " << currGlobalScore << endl;
-		if((currGlobalScore-scorePremodule)<=convThreshold)
-		{
-			notConverged=false;
-		}
-		else
-		{
-			cout << "   Network not converged; score improvement of " << (currGlobalScore-scorePremodule) << ". Redefining modules." << endl;
-			redefineModules();
+
+		notConverged = (currGlobalScore - scorePremodule) > convThreshold;
+
+		if(notConverged) {
+			cout << "   Network not converged; score improvement of " << (currGlobalScore - scorePremodule) << ". Redefining modules." << endl;
+			redefineModules(currFold);
 		}
 
-		scorePremodule=currGlobalScore;
-		dumpAllGraphs(maxFactorSizeApprox,f);
+		scorePremodule = currGlobalScore;
+		dumpAllGraphs(maxFactorSizeApprox, currFold);
 
-		// checkpointing:
+		// Checkpointing
 		writeCheckpointMetadata(iter, notConverged);
 		writePLLScore();
 		writeLastUpdate();
 		doTar();
 
 		iter++;
+		updatedThisIteration.clear();
 	}
 
-	cout <<"Final Score " << currGlobalScore << endl;
-	finalScores[f]=currGlobalScore;
-	return 0;
+	cout << "Final Score " << currGlobalScore << endl;
+	finalScores[currFold] = currGlobalScore;
 }
 
 double
 MetaLearner::getInitPLLScore()
 {
 	double initScore=0;
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	//Initially we just sum up the marginal likelihoods
-	currPLL=new INTDBLMAP;
-	for(VSET_ITER vIter=varSet.begin();vIter!=varSet.end();vIter++)
-	{
+	currPLL=new unordered_map<int, double>;
+	for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
 		if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
 		{
 			continue;
@@ -600,18 +577,16 @@ double
 MetaLearner::getPLLScore()
 {
 	double gScore=0;
-	for(INTDBLMAP_ITER dIter=currPLL->begin();dIter!=currPLL->end();dIter++)
-	{
-		if(isnan(gScore) || isinf(gScore))
-		{
+	for(auto dIter = currPLL->begin(); dIter != currPLL->end(); dIter++) {
+		if(isnan(gScore) || isinf(gScore)) {
 			cout << "Found nan/inf for variable " << dIter->first << endl;
 		}
-		gScore=gScore+dIter->second;
+		gScore += dIter->second;
 	}
 	return gScore;
 }
 
-int
+void
 MetaLearner::clearFoldSpecData()
 {
 	if (factorGraph != nullptr)
@@ -620,29 +595,27 @@ MetaLearner::clearFoldSpecData()
 		factorGraph = nullptr;
 	}
 	edgeMap.clear();
+	sharedParents.clear();
 	if (currPLL != nullptr)
 	{
 		delete currPLL;
 		currPLL = nullptr;
 	}
-	return 0;
 }
 
 int
 MetaLearner::initEdgeSet()
 {
-	VSET& varSet=varManager->getVariableSet();
-	for(VSET_ITER uIter=varSet.begin();uIter!=varSet.end();uIter++)
-	{
-		Variable* u=varSet[uIter->first];
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	for(auto uIter = varSet.begin(); uIter != varSet.end(); uIter++) {
+		Variable* u = varSet[uIter->first];
 		if((restrictedVarList.size()>0) && (restrictedVarList.find(u->getName())==restrictedVarList.end()))
 		{
 			continue;
 		}
 
-		for(VSET_ITER vIter=varSet.begin();vIter!=varSet.end();vIter++)
-		{
-			if(uIter->first==vIter->first)
+		for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
+			if(uIter->first == vIter->first)
 			{
 				continue;
 			}
@@ -651,13 +624,12 @@ MetaLearner::initEdgeSet()
 			{
 				continue;
 			}
+
+			// This is going to be a directed graph. edgeKey looks like "reg_name\tgene_name"
 			string edgeKey;
-			//This is going to be a directed graph. edgeKey looks like "reg_name\tgene_name"
 			edgeKey.append(u->getName().c_str());
 			edgeKey.append("\t");
 			edgeKey.append(v->getName().c_str());
-
-			edgeMap[edgeKey]=0; //initialize this edge to absent for the future LEARNED graph
 
 			double initPrior=getEdgePrior(uIter->first,vIter->first);
 			initPrior = 1/(1+exp(-1*initPrior));
@@ -684,7 +656,6 @@ MetaLearner::initEdgeSet()
 	int n=varSet.size();
 	int r=restrictedVarList.size();
 	int expEdgeCnt=r*(n-1);
-	// cout <<"Initialized " << edgeMap.size() << " edges. Expected " << expEdgeCnt << endl;
 
 	// Init the potentials
 	for(int f=0;f<factorGraph->getFactorCnt();f++)
@@ -699,7 +670,7 @@ MetaLearner::initEdgeSet()
 int
 MetaLearner::getPredictionError_CrossValid(int foldid)
 {
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	char foldoutDirName[1024];
 	sprintf(foldoutDirName,"%s/fold%d",outputDirName,foldid);
 	INTINTMAP& testSet=evidenceManager->getTestSet();
@@ -709,9 +680,9 @@ MetaLearner::getPredictionError_CrossValid(int foldid)
 		//for each gc, get the expected value of this datapoint
 		EMAP* evidMap=evidenceManager->getEvidenceAt(dIter->first);
 
-		for(map<string,int>::iterator vIter=geneModuleID.begin();vIter!=geneModuleID.end();vIter++)
+		for(auto vIter=geneModuleID.begin();vIter!=geneModuleID.end();vIter++)
 		{
-			int vId=varManager->getVarID(vIter->first.c_str());
+			int vId=varManager->getVarID(vIter->first);
 			if(vId==-1)
 			{
 				continue;
@@ -753,9 +724,9 @@ MetaLearner::getPredictionError_CrossValid(int foldid)
 	*/
 	vector<double> truevect;
 	vector<double> predvect;
-	for(map<string,int>::iterator vIter=geneModuleID.begin();vIter!=geneModuleID.end();vIter++)
+	for(auto vIter=geneModuleID.begin();vIter!=geneModuleID.end();vIter++)
 	{
-		int vId=varManager->getVarID(vIter->first.c_str());
+		int vId=varManager->getVarID(vIter->first);
 		if(vId==-1)
 		{
 			continue;
@@ -810,137 +781,132 @@ MetaLearner::getPredictionError_CrossValid(int foldid)
 	return 0;
 }
 
-MetaMove*
-MetaLearner::getNextMove(int maxNumRegs, int vID)
+bool
+MetaLearner::getNextMove(int maxNumRegs, int vID, MetaMove& outMove)
 {
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	Variable* v = varSet[vID];
 
-	if(geneModuleID.find(v->getName()) == geneModuleID.end())
-	{
-		return nullptr;
+	if(geneModuleID.find(v->getName()) == geneModuleID.end()) {
+		return false;
 	}
 
 	// If v already has the max number of parents, dont test adding another.
 	SlimFactor* dFactor = factorGraph->getFactorAt(vID);
-	if(dFactor->mergedMB.size() >= maxNumRegs)
-	{
-		return nullptr;
+	if(dFactor->mergedMB.size() >= maxNumRegs) {
+		return false;
 	}
 
 	// Collect the new set of parents for v
 	vector<int> parentIDs;
-	for (INTINTMAP_ITER iter = dFactor->mergedMB.begin(); iter != dFactor->mergedMB.end(); iter++)
-	{
+	for (INTINTMAP_ITER iter = dFactor->mergedMB.begin(); iter != dFactor->mergedMB.end(); iter++) {
 		parentIDs.push_back(iter->first);
 	}
 
-	int moduleID=geneModuleID[v->getName()];
-	map<string,int>* moduleMembers=moduleGeneSet[moduleID];
-
-	double bestTargetScore=0;
-	double bestScoreImprovement=0;
-	Variable* bestu=NULL;
-	Potential* bestPot=NULL;
-
-	for(map<string,int>::iterator uIter=restrictedVarList.begin();uIter!=restrictedVarList.end();uIter++)
-	{
-		int regID=varManager->getVarID(uIter->first.c_str());
-
-		// Ensure we can find the regulator, and that it isnt the same node as the target.
-		if(regID==-1 || vID==regID)
-		{
-			continue;
-		}
-
-		Variable* u=varSet[regID];
-
-		string edgeKey;
-		edgeKey.append(u->getName().c_str());
-		edgeKey.append("\t");
-		edgeKey.append(v->getName().c_str());
-
-		// If the edge already exists, no need to test adding it.
-		int edgeValue=edgeMap[edgeKey];
-		if(edgeValue==1)
-		{
-			continue;
-		}
-
-		double improvement = 0;
-		double score = 0;
-		Potential* aPot = NULL;
-
-		parentIDs.push_back(u->getID());
-
-		getNewPLLScore(u, v, parentIDs, edgeKey, score, improvement, &aPot);
-
-		parentIDs.pop_back();
-
-		bool betterMoveExists = (bestu != NULL) && (bestScoreImprovement >= improvement);
-
-		// If there is no score improvement, cleanup aPot and continue.
-		if (improvement < 0 || betterMoveExists)
-		{
-			if (aPot != NULL)
-			{
-				delete aPot;
-			}
-			continue;
-		}
-
-		if(bestPot != NULL)
-		{
-			delete bestPot;
-		}
-
-		bestu = u;
-		bestTargetScore = score;
-		bestScoreImprovement = improvement;
-		bestPot = aPot;
-	}
-
-	// If we could not find a parent to add to v that would improve the score:
-	if((bestu == NULL) || (bestScoreImprovement <= 0))
-	{
-		return nullptr;
-	}
-
-	MetaMove* nextMove = new MetaMove;
-	nextMove->setSrcVertex(bestu->getID());
-	nextMove->setTargetVertex(v->getID());
-	nextMove->setTargetMBScore(bestTargetScore);
-	nextMove->setScoreImprovement(bestScoreImprovement);
-	nextMove->setDestPot(bestPot);
-	return nextMove;
-}
-
-void
-MetaLearner::getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential** newdPot)
-{
-	int factorID = v->getID();
-	VSET& varSet = varManager->getVariableSet();
-
-	double plus = 0;
-	double minus = 0;
-	for (vector<int>::iterator iter = parentIDs.begin(); iter != parentIDs.end(); iter++)
-	{
+	double existingParentPlus = 0;
+	double existingParentMinus = 0;
+	for (vector<int>::iterator iter = parentIDs.begin(); iter != parentIDs.end(); iter++) {
 		Variable* parentVar = varSet[*iter];
-		double eprior = getEdgePrior(*iter, factorID);
+		double eprior = getEdgePrior(*iter, vID);
 		double moduleContrib = getModuleContribLogistic((string&)v->getName(), (string&)parentVar->getName());
 		double edgeProb = 1 / (1 + exp(-1 * (eprior + moduleContrib)));
 		double edgeProbOld = 1 / (1 + exp(-1 * eprior));
-		minus += log(1 - edgeProbOld);
-		plus += log(edgeProb);
+		existingParentMinus += log(1 - edgeProbOld);
+		existingParentPlus += log(edgeProb);
 	}
+
+	double existingParentPrior = varNeighborhoodPrior[vID] + existingParentPlus - existingParentMinus;
 
 	INTINTMAP* tSet = &evidenceManager->getTrainingSet();
 	int datasize = tSet->size();
 
-	double currPrior = varNeighborhoodPrior[factorID] + plus - minus;
-	double condLL = potManager->computeLL(factorID, parentIDs, datasize, newdPot);
-	mbScore = condLL + currPrior;
-	scoreImprovement = mbScore - (*currPLL)[factorID];
+	int moduleID = geneModuleID[v->getName()];
+	map<string, int>* moduleMembers = moduleGeneSet[moduleID];
+
+	// Collect all the candidate parents, and the edge priors for each of them.
+	vector<int> candidateParents;
+	vector<double> candidatePriors;
+	for(map<string,int>::iterator uIter = restrictedVarList.begin(); uIter != restrictedVarList.end(); uIter++) {
+		int regID = varManager->getVarID(uIter->first);
+
+		// Ensure we can find the regulator, and that it isnt the same node as the target.
+		if(regID == -1 || vID == regID) {
+			continue;
+		}
+
+		Variable* u = varSet[regID];
+
+		// If the edge already exists, no need to test adding it.
+		auto regEdgeIter = edgeMap.find(regID);
+		if (regEdgeIter != edgeMap.end()) {
+			auto targetEdgeIter = regEdgeIter->second.find(vID);
+			if (targetEdgeIter != regEdgeIter->second.end() && targetEdgeIter->second == 1) {
+				continue;
+			}
+		}
+
+		double candidateEdgePrior = getEdgePrior(regID, vID);
+		double candidateModuleContrib = getModuleContribLogistic((string&)v->getName(), (string&)u->getName());
+		double candidateEdgeProb = 1 / (1 + exp(-1 * (candidateEdgePrior + candidateModuleContrib)));
+		double candidateEdgeProbOld = 1 / (1 + exp(-1 * candidateEdgePrior));
+		double candidatePlus = log(candidateEdgeProb);
+		double candidateMinus = log(1 - candidateEdgeProbOld);
+		double candidatePrior = existingParentPrior + candidatePlus - candidateMinus;
+
+		candidateParents.push_back(regID);
+		candidatePriors.push_back(candidatePrior);
+	}
+
+	// Collect the data likelihood for each candidate parent.
+	unordered_map<int, double> candidateScores;
+	potManager->computeLLs(vID, datasize, parentIDs, candidateParents, candidateScores);
+
+	double bestScore = 0;
+	double bestScoreImprovement = 0;
+	Variable* bestRegulator = NULL;
+
+	// Select the best scoring candidate parent.
+	for (int i = 0; i < candidateParents.size(); i++) {
+		int regID = candidateParents[i];
+		double candidatePrior = candidatePriors[i];
+
+		auto scoreIter = candidateScores.find(regID);
+		if (scoreIter == candidateScores.end()) {
+			continue;
+		}
+
+		double condLL = scoreIter->second;
+		double score = condLL + candidatePrior;
+		double improvement = score - (*currPLL)[vID];
+
+		bool betterMoveExists = (bestRegulator != NULL) && (bestScoreImprovement >= improvement);
+
+		// If there is no score improvement, cleanup aPot and continue.
+		if (improvement < 0 || betterMoveExists) {
+			continue;
+		}
+
+		bestRegulator = varSet[regID];
+		bestScore = score;
+		bestScoreImprovement = improvement;
+	}
+
+	// If we could not find a parent to add to v that would improve the score:
+	if(bestRegulator == NULL || bestScoreImprovement <= 0) {
+		return false;
+	}
+
+	parentIDs.push_back(bestRegulator->getID());
+
+	Potential* potential = potManager->createPotential(vID, parentIDs);
+
+	outMove.setSrcVertex(bestRegulator->getID());
+	outMove.setTargetVertex(v->getID());
+	outMove.setTargetMBScore(bestScore);
+	outMove.setScoreImprovement(bestScoreImprovement);
+	outMove.setDestPot(potential);
+
+	return true;
 }
 
 double
@@ -975,278 +941,245 @@ MetaLearner::getInitPLLScore(int vId)
 double
 MetaLearner::getEdgePrior(int tfID, int targetID)
 {
-	INTDBLMAP* regPriors=NULL;
-	double prior=beta1;
 	double fwt = 0;
-	for (map<string,map<int,INTDBLMAP*>*>::iterator pItr=edgepriormap.begin(); pItr!=edgepriormap.end(); pItr++)
-	{
-		double eweight=0;
-		double gbeta = 0;
-		map<int,INTDBLMAP*>* edgeprior = pItr->second;
-		if(edgeprior->find(targetID)!=edgeprior->end())
-		{
-			regPriors=(*edgeprior)[targetID];
-			if(regPriors->find(tfID)!=regPriors->end())
-			{
-				eweight=(*regPriors)[tfID];
-				gbeta = betamap[pItr->first];
-				fwt = fwt + gbeta*eweight;
-			}
+	for (map<string, unordered_map<int, unordered_map<int, double>*>*>::iterator pItr = edgePriorMap.begin(); pItr != edgePriorMap.end(); pItr++) {
+
+		unordered_map<int, unordered_map<int, double>*>* edgeprior = pItr->second;
+		unordered_map<int, unordered_map<int, double>*>::iterator targetIter = edgeprior->find(targetID);
+		if (targetIter == edgeprior->end()) {
+			continue;
 		}
+
+		unordered_map<int, double>* regPriors = targetIter->second;
+		unordered_map<int, double>::iterator regIter = regPriors->find(tfID);
+		if (regIter == regPriors->end()) {
+			continue;
+		}
+
+		double eWeight = regIter->second;
+		double gBeta = betaMap[pItr->first];
+		fwt += gBeta * eWeight;
 	}
-	prior=beta1+fwt;
-	//if(prior<1e-6)
-	//{
-	//	prior=1e-6;
-	//}
-	//if(prior==1)
-	//{
-	//	prior=1-1e-6;
-	//}
+	double prior = beta1 + fwt;
 	return prior;
 }
 
 void
-MetaLearner::makeMove(MetaMove* nextMove, int currIteration)
+MetaLearner::makeMove(MetaMove& nextMove, int currIteration)
 {
-	VSET& varSet = varManager->getVariableSet();
-	Variable* u = varSet[nextMove->getSrcVertex()];
-	Variable* v = varSet[nextMove->getTargetVertex()];
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	Variable* u = varSet[nextMove.getSrcVertex()];
+	Variable* v = varSet[nextMove.getTargetVertex()];
 
-	string edgeKey;
-	edgeKey.append(u->getName().c_str());
-	edgeKey.append("\t");
-	edgeKey.append(v->getName().c_str());
-
-	SlimFactor* dFactor = factorGraph->getFactorAt(nextMove->getTargetVertex());
+	SlimFactor* dFactor = factorGraph->getFactorAt(nextMove.getTargetVertex());
 
 	// Clean up the old potential
 	delete dFactor->potFunc;
 
 	// Add the new parent and update the potential
-	dFactor->mergedMB[nextMove->getSrcVertex()] = 0;
-	dFactor->potFunc = nextMove->getDestPot();
+	dFactor->mergedMB[nextMove.getSrcVertex()] = 0;
+	dFactor->potFunc = nextMove.getDestPot();
 
 	// Update the current score for this factor
-	(*currPLL)[dFactor->fId] = nextMove->getTargetMBScore();
+	(*currPLL)[dFactor->fId] = nextMove.getTargetMBScore();
 
 	int mID = geneModuleID[v->getName()];
 
 	// Get or create an indegree map for this module
-	map<string,int>* currIndegree=NULL;
-	if(moduleIndegree.find(mID) == moduleIndegree.end())
-	{
-		currIndegree = new map<string,int>;
+	unordered_map<string, int>* currIndegree = NULL;
+	if(moduleIndegree.find(mID) == moduleIndegree.end()) {
+		currIndegree = new unordered_map<string, int>;
 		moduleIndegree[mID] = currIndegree;
-	}
-	else
-	{
+	} else {
 		currIndegree = moduleIndegree[mID];
 	}
 
 	// Increment the count of edges from u to the module of v
-	if(currIndegree->find(u->getName()) == currIndegree->end())
-	{
+	if(currIndegree->find(u->getName()) == currIndegree->end()) {
 		(*currIndegree)[u->getName()] = 1;
-	}
-	else
-	{
+	} else {
 		(*currIndegree)[u->getName()] += 1;
 	}
 
 	// Increment the count of edges from u
-	if(regulatorModuleOutdegree.find(u->getName()) == regulatorModuleOutdegree.end())
-	{
+	if(regulatorModuleOutdegree.find(u->getName()) == regulatorModuleOutdegree.end()) {
 		regulatorModuleOutdegree[u->getName()] = 1;
-	}
-	else
-	{
+	} else {
 		regulatorModuleOutdegree[u->getName()] += 1;
 	}
 
-	edgeMap[edgeKey] = 1;
+	edgeMap[u->getID()][v->getID()] = 1;
 
 	variableStatus[v->getName()] = currIteration;
+
+	updatedThisIteration.push_back(v->getID());
+
+	// Mark all other targets of u as sharing a parent with v.
+	unordered_map<int, int> otherTargets = edgeMap[u->getID()];
+	for (auto iter = otherTargets.begin(); iter != otherTargets.end(); iter++) {
+		int targetID = iter->first;
+		sharedParents[v->getID()][targetID] = 1;
+		sharedParents[targetID][v->getID()] = 1;
+	}
 }
 
 int
 MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid)
 {
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet=varManager->getVariableSet();
 	char aFName[1024];
 	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxFactorSizeApprox);
 	ofstream oFile(aFName);
-	factorGraph->dumpVarMB(oFile,varSet);
+	factorGraph->dumpVarMB(oFile, varSet);
 	oFile.close();
 	return 0;
 }
 
-int
+void
 MetaLearner::initPhysicalDegree()
 {
-	// Early exit: no module can pass hit>4, so entire function is a no-op
-    bool anyLargeModule = false;
-    for (auto& m : moduleGeneSet) {
-        if (m.second->size() > 4) {
-            anyLargeModule = true;
-            break;
-        }
-    }
-    if (!anyLargeModule) {
-        cout << "Skipping initPhysicalDegree: all modules have <=4 genes (hit>4 can never be satisfied)" << endl;
-        return 0;
-    }
-	// if (moduleGeneSet.size() == geneModuleID.size()) // Early exit only for all singleton modules
-	// {
-	// 	cout << "Skipping initPhysicalDegree: singleton modules" << endl;
-	// 	return 0;
-	// }
+	for(map<int, map<string, int>*>::iterator mIter = moduleGeneSet.begin(); mIter != moduleGeneSet.end(); mIter++) {
 
-	for(map<int,map<string,int>*>::iterator mIter=moduleGeneSet.begin();mIter!=moduleGeneSet.end();mIter++)
-	{
-		map<string,int>* indegree=NULL;
-		map<string,map<string,int>*> innet;
-		map<string,int>* geneSet=mIter->second;
-		for(map<string,map<string,map<string,double>*>*>::iterator gpIter=priorgraphmap.begin();gpIter!=priorgraphmap.end();gpIter++)
-		{
-			map<string,int>enrichedTFs;
-			map<string,map<string,double>*>* priorgraph = gpIter->second;
-			getEnrichedTFs(enrichedTFs,geneSet,*priorgraph);
-			for(map<string,int>::iterator tfIter=enrichedTFs.begin();tfIter!=enrichedTFs.end();tfIter++)
-			{
-				map<string,double>* motiftgts=(*priorgraph)[tfIter->first];
-				map<string,int>* ttgts;
-				if (innet.find(tfIter->first) == innet.end())
-				{
-					ttgts = new map<string,int>();
-					innet[tfIter->first] = ttgts;
-				}
-				else
-				{
-					ttgts = innet[tfIter->first];
-				}
-				for(map<string,double>::iterator gIter=motiftgts->begin();gIter!=motiftgts->end();gIter++)
-				{
-					if(geneSet->find(gIter->first)==geneSet->end())
-					{
+		int moduleID = mIter->first;
+		map<string, int>* moduleGenes = mIter->second;
+
+		// Collect the prior edges from enriched TFs to genes in this module, from all prior graphs.
+		unordered_map<string, vector<string>> priorEdges;
+
+		for(map<string, map<string, map<string, double>*>*>::iterator gpIter = priorGraphMap.begin(); gpIter != priorGraphMap.end(); gpIter++) {
+
+			map<string, map<string, double>*>* priorgraph = gpIter->second;
+
+			map<string, int>enrichedTFs;
+			getEnrichedTFs(enrichedTFs, moduleGenes, *priorgraph);
+
+			for(map<string, int>::iterator tfIter = enrichedTFs.begin(); tfIter != enrichedTFs.end(); tfIter++) {
+
+				map<string, double>* motiftgts = (*priorgraph)[tfIter->first];
+				for(map<string, double>::iterator gIter = motiftgts->begin(); gIter != motiftgts->end(); gIter++) {
+					if(moduleGenes->find(gIter->first) == moduleGenes->end()) {
 						continue;
 					}
-					(*ttgts)[gIter->first] = 0;
+					priorEdges[tfIter->first].push_back(gIter->first);
 				}
 			}
 		}
-		for (map<string,map<string,int>*>::iterator tItr=innet.begin();tItr!=innet.end();tItr++)
-		{
-			string tf = tItr->first;
-			map<string,int>* ttgts = tItr->second;
-			if (ttgts->size() == 0)
-			{
+
+		// Save the count of incoming edges per TF.
+		unordered_map<string, int>* indegree = NULL;
+
+		for (auto tItr = priorEdges.begin(); tItr != priorEdges.end(); tItr++) {
+			string regID = tItr->first;
+			int targetCount = tItr->second.size();
+			if (targetCount == 0) {
 				continue;
 			}
-			if (indegree == NULL)
-			{
-				indegree=new map<string,int>;
+			if (indegree == NULL) {
+				indegree = new unordered_map<string, int>;
 			}
-			(*indegree)[tf] = ttgts->size();
+			(*indegree)[regID] = targetCount;
 		}
 
-		if(indegree!=NULL)
-		{
-			moduleIndegree[mIter->first]=indegree;
-			cout << "Module " << mIter->first << ": " << geneSet->size() << " genes, " << indegree->size() << " enriched TFs" << endl;
-			for(map<string,int>::iterator dIter=indegree->begin();dIter!=indegree->end();dIter++)
-			{
-				cout << " Enriched TF " << dIter->first << ": " << dIter->second << " target genes in this module across prior networks" <<endl;
-				if(regulatorModuleOutdegree.find(dIter->first)==regulatorModuleOutdegree.end())
-				{
-					regulatorModuleOutdegree[dIter->first]=dIter->second;
-				}
-				else
-				{
-					regulatorModuleOutdegree[dIter->first]=regulatorModuleOutdegree[dIter->first]+dIter->second;
-				}
-			}
-		}
-	}
-
-	return 0;
-}
-
-int
-MetaLearner::getEnrichedTFs(map<string,int>& tfSet,map<string,int>* genes,map<string,map<string,double>*>& edgeSet)
-{
-	VSET& varSet=varManager->getVariableSet();
-	int total=varSet.size();
-	int k=genes->size();
-	HyperGeomPval hgp;
-	for(map<string,map<string,double>*>::iterator fIter=edgeSet.begin();fIter!=edgeSet.end();fIter++)
-	{
-		int uID=varManager->getVarID(fIter->first.c_str());
-		if(uID<0)
-		{
+		if(indegree == NULL) {
 			continue;
 		}
-		map<string,double>* tgtSet=fIter->second;
-		//int n=tgtSet->size();
-		int n=0;
-		int hit=0;
-		for(map<string,double>::iterator gIter=tgtSet->begin();gIter!=tgtSet->end();gIter++)
-		//for(map<string,int>::iterator gIter=genes->begin();gIter!=genes->end();gIter++)
-		{
 
-			int vID=varManager->getVarID(gIter->first.c_str());
-            if(vID<0)
-            {
-                continue;
-            }
-            n++;
-			//if(tgtSet->find(gIter->first)==tgtSet->end())
-            if(genes->find(gIter->first)==genes->end())
-			{
-				continue;
+		moduleIndegree[mIter->first] = indegree;
+		cout << "Module " << moduleID << ": " << moduleGenes->size() << " genes, " << indegree->size() << " enriched TFs" << endl;
+
+		// Increment the total count of outgoing edges for each TF
+
+		for(auto dIter = indegree->begin(); dIter != indegree->end(); dIter++) {
+			cout << " Enriched TF " << dIter->first << ": " << dIter->second << " target genes in this module across prior networks" <<endl;
+			if(regulatorModuleOutdegree.find(dIter->first) == regulatorModuleOutdegree.end()) {
+				regulatorModuleOutdegree[dIter->first] = dIter->second;
+			} else {
+				regulatorModuleOutdegree[dIter->first] = regulatorModuleOutdegree[dIter->first] + dIter->second;
 			}
-			hit++;
-		}
-		double enpval=hgp.getOverRepPval(k,hit,n,total-n);
-		if(enpval<0.05 && hit>4)
-		//if(hit>0)
-		{
-			tfSet[fIter->first]=hit;
 		}
 	}
-	return 0;
+}
+
+void
+MetaLearner::getEnrichedTFs(map<string, int>& tfSet, map<string, int>* moduleGenes, map<string, map<string, double>*>& edgeSet)
+{
+	// A tf is enriched for a module, if it has at least 4 targets within that module, and
+	// more module members than expected are targets of the tf.
+
+	// We require 4 in-module targets in order for a tf to be enriched. If there aren't 4 total
+	// module genes, then no tf can be enriched.
+	if (moduleGenes->size() < 4) {
+		return;
+	}
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	int varCount = varSet.size();
+	int moduleVarCount = moduleGenes->size();
+
+	HyperGeomPval hgp;
+	for(map<string, map<string, double>*>::iterator fIter = edgeSet.begin(); fIter != edgeSet.end(); fIter++) {
+		int uID = varManager->getVarID(fIter->first);
+		if(uID < 0) {
+			continue;
+		}
+
+		map<string,double>* tgtSet = fIter->second;
+
+		int targetsCount = 0;
+		int targetsInModuleCount = 0;
+
+		for(map<string, double>::iterator gIter = tgtSet->begin(); gIter != tgtSet->end(); gIter++) {
+			int vID = varManager->getVarID(gIter->first);
+            if(vID < 0) {
+                continue;
+            }
+
+            targetsCount++;
+
+            if(moduleGenes->find(gIter->first) != moduleGenes->end()) {
+				targetsInModuleCount++;
+			}
+		}
+
+		double enpval = hgp.getOverRepPval(moduleVarCount, targetsInModuleCount, targetsCount, varCount - targetsCount);
+		if (enpval < 0.05 && targetsInModuleCount > 4) {
+			tfSet[fIter->first] = targetsInModuleCount;
+		}
+	}
 }
 
 double
 MetaLearner::getModuleContribLogistic(string& tgtName, string& tfName)
 {
-	if(geneModuleID.find(tgtName)==geneModuleID.end())
-	{
+	auto moduleIter = geneModuleID.find(tgtName);
+	if(moduleIter == geneModuleID.end()) {
 		return 0;
 	}
 
-	int moduleID=geneModuleID[tgtName];
-	if(moduleIndegree.find(moduleID)==moduleIndegree.end())
-	{
+	int moduleID = moduleIter->second;
+
+	auto degreeIter = moduleIndegree.find(moduleID);
+	if(degreeIter == moduleIndegree.end()) {
 		return 0;
 	}
 
-	map<string,int>* moddegree=moduleIndegree[moduleID];
-	if(moddegree->find(tfName)==moddegree->end())
-	{
+	unordered_map<string,int>* moddegree = degreeIter->second;
+
+	auto regIter = moddegree->find(tfName);
+	if(regIter == moddegree->end()) {
 		return 0;
 	}
 
-	int degree=(*moddegree)[tfName];
+	int degree = regIter->second;
+	int regDegree = 0;
 
-	int regDegree=0;
-	if(regulatorModuleOutdegree.find(tfName)!=regulatorModuleOutdegree.end())
-	{
-		regDegree=regulatorModuleOutdegree[tfName];
+	auto outDegreeIter = regulatorModuleOutdegree.find(tfName);
+	if(outDegreeIter != regulatorModuleOutdegree.end()) {
+		regDegree = outDegreeIter->second;
 	}
 
-	double contrib=((double) degree)/((double) regDegree);
-	return beta_motif*contrib;
+	double contrib= ((double) degree) / ((double) regDegree);
+	return beta_motif * contrib;
 }
 
 //To redefine the modules we will start with the original set of modules
@@ -1255,76 +1188,57 @@ MetaLearner::getModuleContribLogistic(string& tgtName, string& tfName)
 //regulatory program. recompute similarity of all nodes to this merged node. repeat with
 //finding the next most similar pair of nodes.
 
-int
-MetaLearner::redefineModules()
+void
+MetaLearner::redefineModules(int currFold)
 {
 	INTINTMAP& tSet=evidenceManager->getTrainingSet();
 
-	if (correlationDistances == nullptr)
-	{
-		initCorrelationDistances();
+	if (correlationDistances == nullptr) {
+		initDistances();
 	}
 
 	map<string,int> genesWithNoNeighbors;
 
 	// Create a node for each member of each module
-	for(map<int,map<string,int>*>::iterator gIter=moduleGeneSet.begin();gIter!=moduleGeneSet.end();gIter++)
-	{
-		map<string,int>* moduleMembers=gIter->second;
-		for(map<string,int>::iterator mIter=moduleMembers->begin();mIter!=moduleMembers->end();mIter++)
-		{
-			int mID=varManager->getVarID(mIter->first.c_str());
-			if(mID<0)
-			{
+	for(map<int, map<string, int>*>::iterator gIter = moduleGeneSet.begin(); gIter != moduleGeneSet.end(); gIter++) {
+		map<string, int>* moduleMembers=gIter->second;
+
+		for(map<string, int>::iterator mIter = moduleMembers->begin(); mIter != moduleMembers->end(); mIter++) {
+			int mID = varManager->getVarID(mIter->first);
+			if(mID < 0) {
 				continue;
 			}
 			SlimFactor* mFactor=factorGraph->getFactorAt(mID);
 
 			// If a gene has no neighbors, we dont include it in the clustering algorithm.
-			INTINTMAP& mbvars1=mFactor->mergedMB;
-			if(mbvars1.size()==0)
-			{
-				genesWithNoNeighbors[mIter->first]=0;
+			INTINTMAP& mbvars1 = mFactor->mergedMB;
+			if(mbvars1.size() == 0) {
+				genesWithNoNeighbors[mIter->first] = 0;
 				continue;
 			}
 
 			// Create a node for this gene
 			HierarchicalClusterNode* node = hc.getNode(mIter->first);
-			if (node == nullptr)
-			{
+			if (node == nullptr) {
 				node = new HierarchicalClusterNode;
 				node->nodeName.append(mIter->first);
 				node->varID = mID;
 				hc.addNode(node);
-
-				// Add expression data on the new node
-				for(INTINTMAP_ITER eIter=tSet.begin();eIter!=tSet.end();eIter++)
-				{
-					EMAP* evidMap=evidenceManager->getEvidenceAt(eIter->first);
-					Evidence* evid=(*evidMap)[mID];
-					double v=evid->getEvidVal();
-					node->expr.push_back(v);
-				}
-			}
-
-			// Add weights for incoming edges onto the node
-			INTDBLMAP& regWts=mFactor->potFunc->getWeights();
-			for(INTDBLMAP_ITER bIter=regWts.begin();bIter!=regWts.end();bIter++)
-			{
-				node->attrib[bIter->first]=bIter->second;
 			}
 		}
 	}
 
+	updateSharedParentDistances();
+
 	// Perform the new clustering
 	map<int,map<string,int>*> newModules;
-	hc.cluster(newModules, clusterThreshold, correlationDistances);
+	hc.cluster(newModules, clusterThreshold, correlationDistances, sharedParentDistances);
 
 	// Clear out any data representing the old module assignments
 	moduleGeneSet.clear();
 	geneModuleID.clear();
 	regulatorModuleOutdegree.clear();
-	for(map<int,map<string,int>*>::iterator mIter=moduleIndegree.begin();mIter!=moduleIndegree.end();mIter++)
+	for(auto mIter=moduleIndegree.begin(); mIter!=moduleIndegree.end(); mIter++)
 	{
 		mIter->second->clear();
 		delete mIter->second;
@@ -1337,17 +1251,17 @@ MetaLearner::redefineModules()
 
 	// Read in the new module assignments
 	int largestModuleID=0;
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	for(map<int,map<string,int>*>::iterator mIter=newModules.begin();mIter!=newModules.end();mIter++)
 	{
 		moduleGeneSet[mIter->first]=mIter->second;
 		map<string,int>* geneSet=mIter->second;
-		map<string,int>* indegree=new map<string,int>;
+		unordered_map<string, int>* indegree = new unordered_map<string,int>;
 		for(map<string,int>::iterator gIter=geneSet->begin();gIter!=geneSet->end();gIter++)
 		{
 			modFile << gIter->first <<"\t" << mIter->first << endl;
 			geneModuleID[gIter->first]=mIter->first;
-			int mID=varManager->getVarID(gIter->first.c_str());
+			int mID=varManager->getVarID(gIter->first);
 			SlimFactor* mFactor=factorGraph->getFactorAt(mID);
 			INTINTMAP& mbvars1=mFactor->mergedMB;
 
@@ -1391,26 +1305,22 @@ MetaLearner::redefineModules()
 	}
 	genesWithNoNeighbors.clear();
 	cout << "   Finished redefining modules; " << moduleGeneSet.size() << " total modules" << endl;
-
-	return 0;
 }
 
 void
-MetaLearner::initCorrelationDistances()
+MetaLearner::initDistances()
 {
 	INTINTMAP& samples = evidenceManager->getTrainingSet();
-	VSET& varSet = varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 
 	int varCount = varSet.size();
 	int sampleCount = samples.size();
 
 	vector<double> means(varCount, 0);
 
-	for (INTINTMAP_ITER iter = samples.begin(); iter != samples.end(); iter++)
-	{
+	for (INTINTMAP_ITER iter = samples.begin(); iter != samples.end(); iter++) {
 		EMAP* evidMap = evidenceManager->getEvidenceAt(iter->first);
-		for (int i = 0; i < varCount; i++)
-		{
+		for (int i = 0; i < varCount; i++) {
 			Evidence* evid=(*evidMap)[i];
 			means[i] += evid->getEvidVal();
 		}
@@ -1424,11 +1334,9 @@ MetaLearner::initCorrelationDistances()
 	vector<vector<double>> deviations(varCount, vector<double>(sampleCount, 0));
 
 	int sampleIndex = 0;
-	for (INTINTMAP_ITER iter = samples.begin(); iter != samples.end(); iter++)
-	{
+	for (INTINTMAP_ITER iter = samples.begin(); iter != samples.end(); iter++) {
 		EMAP* evidMap = evidenceManager->getEvidenceAt(iter->first);
-		for (int i = 0; i < varSet.size(); i++)
-		{
+		for (int i = 0; i < varCount; i++) {
 			double deviation = (*evidMap)[i]->getEvidVal() - means[i];
 			deviations[i][sampleIndex] = deviation;
 			ssd[i] += deviation * deviation;
@@ -1440,19 +1348,20 @@ MetaLearner::initCorrelationDistances()
 
 	double threshold = sampleCount / 2.0;
 
-	for (int i = 0; i < varCount; i++)
-	{
-		double xx = ssd[i];
+	vector<double> invStd(varCount, 0);
+	for (int i = 0; i < varCount; i++) {
+		invStd[i] = 1.0 / sqrt(ssd[i]);
+	}
+
+	for (int i = 0; i < varCount; i++) {
 		double* dev_i = deviations[i].data();
 
-		for (int j = i; j < varCount; j++)
-		{
+		for (int j = i; j < varCount; j++) {
 			double* dev_j = deviations[j].data();
 			double xy = 0;
 			int oppRel = 0;
 
-			for(int k = 0; k < sampleCount; k++)
-			{
+			for(int k = 0; k < sampleCount; k++) {
 				double diff1 = dev_i[k];
 				double diff2 = dev_j[k];
 				double val = diff1 * diff2;
@@ -1460,11 +1369,9 @@ MetaLearner::initCorrelationDistances()
 				oppRel += (val < 0);
 			}
 
-			double yy = ssd[j];
-			double cc = abs(xy) / sqrt(xx * yy);
+			double cc = abs(xy) * invStd[i] * invStd[j];
 
-			if(oppRel > threshold)
-			{
+			if(oppRel > threshold) {
 				cc *= -1;
 			}
 
@@ -1474,10 +1381,11 @@ MetaLearner::initCorrelationDistances()
 			correlationDistances->setValue(cc, j, i);
 		}
 	}
+
+	// Initially we have no edges, so no nodes share a parent, and all distances are 1.
+	sharedParentDistances = new Matrix(varCount, varCount);
+	sharedParentDistances->setAllValues(1);
 }
-
-
-// checkpointing additions
 
 int
 MetaLearner::writeCheckpointMetadata(int iter, bool notConvergedVal)
@@ -1518,25 +1426,25 @@ MetaLearner::readCheckpointMetadata(int& iter, bool& notConvergedVal)
 int 
 MetaLearner::writePLLScore()
 {
-    char aFName[1024];
-    sprintf(aFName, "%s/pll.txt", foldoutDirName);
-    ofstream outFile(aFName);
-    VSET& varSet = varManager->getVariableSet();
-	if (currPLL == NULL)
-	{
+	if (currPLL == NULL) {
 		return -1;
 	}
-	INTDBLMAP* plls = currPLL;
+
+    char aFName[1024];
+    sprintf(aFName, "%s/pll.txt", foldoutDirName);
+
+    ofstream outFile(aFName);
 
 	// Force maximum double precision to prevent truncation
     outFile << std::setprecision(std::numeric_limits<double>::max_digits10);
 
-    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
-    {
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+    for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
         Variable* var = varSet[vIter->first];
-        if (geneModuleID.find(var->getName()) == geneModuleID.end())
-            continue;
-        outFile << var->getName() << "\t" << (*plls)[vIter->first] << endl;
+        if (geneModuleID.find(var->getName()) == geneModuleID.end()) {
+			continue;
+		}
+        outFile << var->getName() << "\t" << (*currPLL)[vIter->first] << endl;
     }
     outFile.close();
     return 0;
@@ -1547,18 +1455,18 @@ MetaLearner::loadInitPLLScore()
 {
     char aFName[1024];
     sprintf(aFName, "%s/pll.txt", foldoutDirName);
-    ifstream inFile(aFName);
-    char buffer[1024];
 
-    VSET& varSet = varManager->getVariableSet();
-    INTDBLMAP* plls = new INTDBLMAP;
-	if (currPLL != NULL)
-	{
+    ifstream inFile(aFName);
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
+	if (currPLL != NULL) {
 		delete currPLL;
 	}
-	currPLL = plls;
+	currPLL = new unordered_map<int, double>;
 
     double initScore = 0;
+	char buffer[1024];
 
     while (inFile.good())
     {
@@ -1585,7 +1493,7 @@ MetaLearner::loadInitPLLScore()
             tok = strtok(NULL, "\t");
             tokCnt++;
         }
-        (*plls)[v->getID()] = val;
+        (*currPLL)[v->getID()] = val;
         initScore += val;
     }
     return initScore;
@@ -1596,9 +1504,11 @@ MetaLearner::writeLastUpdate()
 {
     char aFName[1024];
     sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+
     ofstream outFile(aFName);
-    VSET& varSet = varManager->getVariableSet();
-    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+    for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++)
     {
         Variable* var = varSet[vIter->first];
         if (geneModuleID.find(var->getName()) == geneModuleID.end())
@@ -1616,10 +1526,13 @@ MetaLearner::loadLastUpdate()
 {
     char aFName[1024];
     sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+
     ifstream inFile(aFName);
-    char buffer[1024];
-    VSET& varSet = varManager->getVariableSet();
-    while (inFile.good())
+
+	char buffer[1024];
+    unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
+	while (inFile.good())
     {
         inFile.getline(buffer, 1023);
         if (strlen(buffer) <= 0) 
@@ -1628,14 +1541,14 @@ MetaLearner::loadLastUpdate()
 		}
         char* tok = strtok(buffer, "\t");
         int tokCnt = 0;
-        Variable* v = NULL;
+        Variable* var = NULL;
         int titer = 0;
         while (tok != NULL)
         {
             if (tokCnt == 0) 
 			{ 
 				int vid = varManager->getVarID(tok); 
-				v = varSet[vid]; 
+				var = varSet[vid]; 
 			}
             else 
 			{ 
@@ -1644,7 +1557,7 @@ MetaLearner::loadLastUpdate()
             tok = strtok(NULL, "\t");
             tokCnt++;
         }
-        variableStatus[v->getName()] = titer;
+        variableStatus[var->getName()] = titer;
     }
     return 0;
 }
@@ -1725,9 +1638,9 @@ MetaLearner::readCheckpointModuleMembership()
     inFile.close();
 
     // Recreate singleton modules (for parentless genes) that were not written to modules.txt
-    VSET& varSet = varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
     int genesWithNoNeighborsCount = 0;
-    for(VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++)
     {
         Variable* v = vIter->second;
         string geneName = v->getName();
@@ -1747,14 +1660,12 @@ MetaLearner::readCheckpointModuleMembership()
     return 0;
 }
 
-
 int
 MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 {
 	// Clear previous degree distributions
 	moduleIndegree.clear();
 	regulatorModuleOutdegree.clear();
-	//edgeMap.clear(); we want to keep the initialized edges, and only set them to 1 if we see them.
 
 	char aFName[1024];
     sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSizeApprox);
@@ -1766,7 +1677,7 @@ MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 	}
 	
 	char buffer[1024];
-	VSET& varSet=varManager->getVariableSet();
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 
 	// Parse edges and track degrees
 	while(inFile.good())
@@ -1810,10 +1721,10 @@ MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 
 		// Track in-degree counts for the module containing the destination variable 'v'
 		int mID=geneModuleID[v->getName()];
-		map<string,int>* currIndegree=NULL;
+		unordered_map<string, int>* currIndegree=NULL;
 		if(moduleIndegree.find(mID)==moduleIndegree.end())
 		{
-			currIndegree=new map<string,int>;
+			currIndegree = new unordered_map<string, int>;
 			moduleIndegree[mID]=currIndegree;
 		}
 		else
@@ -1847,11 +1758,7 @@ MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 		dFactor->mergedMB[sFactor->fId]=0;
 
 		// Record the unique edge path string in the global edge map
-		string edgeKey;
-		edgeKey.append(u->getName().c_str());
-		edgeKey.append("\t");
-		edgeKey.append(v->getName().c_str());
-		edgeMap[edgeKey]=1;
+		edgeMap[u->getID()][v->getID()] = 1;
 	}
 
 	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
@@ -1865,6 +1772,7 @@ MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 			delete sFactor->potFunc;
 			sFactor->potFunc = NULL;
 		}
+
 		if (sFactor->mergedMB.size() == 0)
 		{
 			sFactor->potFunc = potManager->createPotential(sFactor->fId);
@@ -1872,21 +1780,105 @@ MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
 		}
 
 		vector<int> parentIDs;
-		for(INTINTMAP_ITER mIter=sFactor->mergedMB.begin();mIter!=sFactor->mergedMB.end();mIter++)
+		for(auto mIter=sFactor->mergedMB.begin();mIter!=sFactor->mergedMB.end();mIter++)
 		{
 			parentIDs.push_back(mIter->first);
 		}
 
-		Potential* restoredPot = NULL;
-		potManager->computeLL(sFactor->fId, parentIDs, evidenceManager->getTrainingSet().size(), &restoredPot);
-		if (restoredPot == NULL)
-		{
+		Potential* restoredPot = potManager->createPotential(sFactor->fId, parentIDs);
+
+		if (restoredPot == NULL) {
 			sFactor->potFunc = potManager->createPotential(sFactor->fId);
-			continue;
+		} else {
+			sFactor->potFunc = restoredPot;
 		}
-		sFactor->potFunc = restoredPot;
 	}
 
 	inFile.close();
 	return 0;
+}
+
+void
+MetaLearner::updateSharedParentDistances()
+{
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	int varCount = varSet.size();
+
+	int updateCount = 0;
+
+	sort(updatedThisIteration.begin(), updatedThisIteration.end());
+
+	vector<bool> willVisit(varCount, false);
+	for (int k = 0; k < updatedThisIteration.size(); k++) {
+		willVisit[updatedThisIteration[k]] = true;
+	}
+
+	vector<double> denoms(varCount, 0);
+
+	for (auto iter = updatedThisIteration.begin(); iter != updatedThisIteration.end(); iter++) {
+		int varID = *iter;
+		SlimFactor* factorA = factorGraph->getFactorAt(varID);
+		vector<pair<int, double>>& weightsA = factorA->potFunc->getWeights();
+
+		double denomA = denoms[varID];
+		if (denomA == 0) {
+			for (const auto& weight : weightsA) {
+				denomA += fabs(weight.second);
+			}
+			denoms[varID] = denomA;
+		}
+
+		unordered_map<int, int>& siblingVarIDs = sharedParents[varID];
+
+		for (auto siblingIter = siblingVarIDs.begin(); siblingIter != siblingVarIDs.end(); siblingIter++) {
+			int siblingID = siblingIter->first;
+
+			if (varID == siblingID) {
+				continue;
+			}
+
+			if (willVisit[siblingID] && siblingID < varID) {
+				continue;
+			}
+
+			updateCount += 1;
+
+			SlimFactor* factorB = factorGraph->getFactorAt(siblingID);
+			vector<pair<int, double>>& weightsB = factorB->potFunc->getWeights();
+
+			double denomB = denoms[siblingID];
+			if (denomB == 0) {
+				for (const auto& weight : weightsB) {
+					denomB += fabs(weight.second);
+				}
+				denoms[siblingID] = denomB;
+			}
+
+			auto itA = weightsA.begin();
+			auto itB = weightsB.begin();
+			double sharedSign = 0;
+
+			while (itA != weightsA.end() && itB != weightsB.end()) {
+				if (itA->first == itB->first) {
+					double weight1 = itA->second;
+					double weight2 = itB->second;
+					if ((weight1 >= 0.0) == (weight2 >= 0.0)) {
+						sharedSign += (fabs(weight1) + fabs(weight2)) * 0.5;
+					}
+					++itA;
+					++itB;
+				} else if (itA->first < itB->first) {
+					++itA;
+				} else {
+					++itB;
+				}
+			}
+
+			double distance = 1 - sharedSign / (denomA + denomB - sharedSign);
+			sharedParentDistances->setValue(distance, varID, siblingID);
+			sharedParentDistances->setValue(distance, siblingID, varID);
+		}
+	}
+
+	std::cout << "Number of distance updates: " << updateCount << std::endl;
 }

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -589,17 +589,24 @@ MetaLearner::getPLLScore()
 void
 MetaLearner::clearFoldSpecData()
 {
-	if (factorGraph != nullptr)
-	{
+	hc = HierarchicalCluster();
+	edgeMap.clear();
+	sharedParents.clear();
+	if (factorGraph != nullptr) {
 		delete factorGraph;
 		factorGraph = nullptr;
 	}
-	edgeMap.clear();
-	sharedParents.clear();
-	if (currPLL != nullptr)
-	{
+	if (currPLL != nullptr) {
 		delete currPLL;
 		currPLL = nullptr;
+	}
+	if (correlationDistances != nullptr) {
+		delete correlationDistances;
+		correlationDistances = nullptr;
+	}
+	if (sharedParentDistances != nullptr) {
+		delete sharedParentDistances;
+		sharedParentDistances = nullptr;
 	}
 }
 
@@ -1879,6 +1886,4 @@ MetaLearner::updateSharedParentDistances()
 			sharedParentDistances->setValue(distance, siblingID, varID);
 		}
 	}
-
-	std::cout << "Number of distance updates: " << updateCount << std::endl;
 }

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -30,7 +30,6 @@ MetaLearner::MetaLearner()
 {
 	shouldLoadCheckpoint = false;
 	restrictedFName[0]='\0';
-	preRandomizeSplit=false;
 	random=false;
 	clusterThreshold=0.5;
 	specificFold=-1;
@@ -163,13 +162,6 @@ MetaLearner::setRestrictedList(const char* aFName)
 	}
 	inFile.close();
 	std::cout << "Number of regulators read: " << count << std::endl;
-}
-
-
-void
-MetaLearner::setPreRandomizeSplit()
-{
-	preRandomizeSplit=true;
 }
 
 void

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -5,8 +5,6 @@
 #include <sys/timeb.h>
 #include <sys/time.h>
 #include <time.h>
-#include <iomanip>
-#include <limits>
 #include <algorithm>
 
 #include "Error.H"
@@ -26,6 +24,7 @@
 #include "HierarchicalCluster.H"
 #include "HyperGeomPval.H"
 #include "MetaLearner.H"
+#include "Checkpoint.H"
 
 MetaLearner::MetaLearner()
 {
@@ -449,52 +448,31 @@ MetaLearner::start(int currFold)
 {
 	sprintf(foldoutDirName, "%s/fold%d", outputDirName, currFold);
 
-	int iter = 0;
-	bool notConverged=true;
-	bool loadedMetadata = false;
-	if(shouldLoadCheckpoint)
-	{
-		loadedMetadata = readCheckpointMetadata(iter, notConverged);
-		if (loadedMetadata)
-		{
-			iter++;
-		}
+	// populates edgePriorMap
+	initEdgePriorMeta_All();
+
+	// populates edgeMap, edgePresenceProb, varNeighborhoodPrior, potentials
+	initEdgeSet();
+
+	bool checkpointLoaded = false;
+	Checkpoint checkpoint(foldoutDirName, maxFactorSize);
+	if (shouldLoadCheckpoint) {
+		checkpointLoaded = checkpoint.loadCheckpointData();
 	}
 
-	initEdgePriorMeta_All(); // populates edgePriorMap
-	initEdgeSet(); // populates edgeMap, edgePresenceProb, varNeighborhoodPrior, potentials
-
+	int iter = 0;
+	bool notConverged = true;
 	double currGlobalScore = 0;
+
+	if (checkpointLoaded) {
+		setupFoldState(checkpoint, iter, notConverged, currGlobalScore);
+	} else {
+		setupFoldState(currGlobalScore);
+	}
+
 	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 
-	if (shouldLoadCheckpoint && loadedMetadata) {
-
-		// overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
-		cout << "Read modules..." << endl;
-		readCheckpointModuleMembership();
-
-		// populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
-		cout << "Read networks..." << endl;
-		populateGraphsFromFile();
-
-		currGlobalScore = loadInitPLLScore(); 
-
-		// populates variableStatus
-		loadLastUpdate(); 
-
-	} else {
-		// populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
-		initPhysicalDegree();
-
-		for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
-			Variable *var = vIter->second;
-			variableStatus[var->getName()] = 0;
-		}
-
-		currGlobalScore = getInitPLLScore();
-	}
-
-	while(notConverged && iter<50) {
+	while(notConverged && iter < 50) {
 		cout << "Beginning regulator identification of iter " << iter << endl;
 
 		int varID = 0;
@@ -539,13 +517,8 @@ MetaLearner::start(int currFold)
 		}
 
 		scorePremodule = currGlobalScore;
-		dumpAllGraphs(currFold);
 
-		// Checkpointing
-		writeCheckpointMetadata(iter, notConverged);
-		writePLLScore();
-		writeLastUpdate();
-		doTar();
+		writeFoldProgress(currFold, iter, notConverged, checkpoint);
 
 		iter++;
 		updatedThisIteration.clear();
@@ -555,25 +528,175 @@ MetaLearner::start(int currFold)
 	finalScores[currFold] = currGlobalScore;
 }
 
-double
-MetaLearner::getInitPLLScore()
+void
+MetaLearner::writeFoldProgress(int currFold, int iter, bool notConverged, Checkpoint& checkpoint)
 {
-	double initScore=0;
 	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	dumpAllGraphs(currFold);
+	checkpoint.writeCheckpointMetadata(iter, notConverged);
+	checkpoint.writePLLScore(currPLL, varSet);
+	checkpoint.writeLastUpdate(variableStatus);
+	checkpoint.doTar();
+}
+
+void
+MetaLearner::setupFoldState(double& globalScore)
+{
+	// populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
+	initPhysicalDegree();
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+	for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
+		Variable *var = vIter->second;
+		variableStatus[var->getName()] = 0;
+	}
+
+	currPLL = new unordered_map<int, double>;
+	globalScore = 0;
+
 	//Initially we just sum up the marginal likelihoods
-	currPLL=new unordered_map<int, double>;
 	for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
-		if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
-		{
+		if (varNeighborhoodPrior.find(vIter->first) == varNeighborhoodPrior.end()) {
 			continue;
 		}
-		Variable* var=varSet[vIter->first];
-		double newPLL_s=getInitPLLScore(vIter->first);
-		double priorScore=varNeighborhoodPrior[vIter->first];
-		(*currPLL)[vIter->first]=newPLL_s+priorScore;
-		initScore=initScore+(*currPLL)[vIter->first];
+		Variable* var = varSet[vIter->first];
+		double newPLL_s = getInitPLLScore(vIter->first);
+		double priorScore = varNeighborhoodPrior[vIter->first];
+		(*currPLL)[vIter->first] = newPLL_s + priorScore;
+		globalScore += (*currPLL)[vIter->first];
 	}
-	return initScore;
+}
+
+void
+MetaLearner::setupFoldState(Checkpoint& checkpoint, int& iter, bool& notConverged, double& globalScore)
+{
+	// Sets up all the global state that needs to be configured before beginning a fold, based on the Checkpoint data
+
+	iter = checkpoint.getIteration();
+	notConverged = checkpoint.getHasNotConverged();
+	globalScore = checkpoint.getInitialScore();
+	variableStatus = checkpoint.getVariableStatus();
+
+	currPLL = new unordered_map<int, double>;
+
+	// Load the saved pseudo-likelihood for each variable
+	unordered_map<string, double> initialPLLs = checkpoint.getInitialPLLs();
+	for (auto iter = initialPLLs.begin(); iter != initialPLLs.end(); iter++) {
+		int varID = varManager->getVarID(iter->first);
+		(*currPLL)[varID] = iter->second;
+	}
+
+	// populates moduleGeneSet, geneModuleID
+	restoreCheckpointModules(checkpoint.getGeneModuleIDs());
+
+	// populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
+	restoreCheckpointGraph(checkpoint.getEdges());
+}
+
+void
+MetaLearner::restoreCheckpointModules(const unordered_map<string, int>& checkpointGeneModuleIDs)
+{
+	cout << "Load checkpoint modules..." << endl;
+
+	geneModuleID = checkpointGeneModuleIDs;
+
+	// Clear out the initial module gene sets
+	for (auto iter = moduleGeneSet.begin(); iter != moduleGeneSet.end(); iter++) {
+		delete iter->second;
+	}
+	moduleGeneSet.clear();
+
+    // Build the module gene sets
+	int largestModuleID = 0;
+	for (auto iter = geneModuleID.begin(); iter != geneModuleID.end(); iter++) {
+        int moduleID = iter->second;
+		if (moduleGeneSet.find(moduleID) == moduleGeneSet.end()) {
+			moduleGeneSet[moduleID] = new map<string, int>;
+		}
+		(*moduleGeneSet[moduleID])[iter->first] = 0;
+        if (moduleID > largestModuleID) {
+            largestModuleID = moduleID;
+        }
+	}
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
+    // Recreate singleton modules (for parentless genes) that were not written to modules.txt
+    int genesWithNoNeighborsCount = 0;
+    for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
+        Variable* v = vIter->second;
+        string geneName = v->getName();
+        if(geneModuleID.find(geneName) != geneModuleID.end()) {
+            continue;
+        }
+        largestModuleID++;
+        moduleGeneSet[largestModuleID] = new map<string, int>;
+        (*moduleGeneSet[largestModuleID])[geneName] = 0;
+        geneModuleID[geneName] = largestModuleID;
+        genesWithNoNeighborsCount++;
+    }
+
+    cout << "Recovered " << genesWithNoNeighborsCount << " parentless genes not present in modules.txt" << endl;
+    cout << "Total modules after recovery: " << moduleGeneSet.size() << endl;
+}
+
+void
+MetaLearner::restoreCheckpointGraph(const vector<pair<string, string>>& checkpointEdges)
+{
+	cout << "Load checkpoint edges..." << endl;
+
+	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
+	for (const pair<string, string>& edge : checkpointEdges) {
+		int regID = varManager->getVarID(edge.first);
+		int targetID = varManager->getVarID(edge.second);
+
+		if (varSet.find(regID) == varSet.end() || varSet.find(targetID) == varSet.end()) {
+			continue;
+		}
+
+		Variable* regulator = varSet[regID];
+		Variable* target = varSet[targetID];
+		int moduleID = geneModuleID[target->getName()];
+
+		if (moduleIndegree.find(moduleID) == moduleIndegree.end()) {
+			moduleIndegree[moduleID] = new unordered_map<string, int>;
+		}
+
+		(*moduleIndegree[moduleID])[regulator->getName()] += 1;
+
+		regulatorModuleOutdegree[regulator->getName()] += 1;
+
+		// Update the Factor Graph: Add source to target gene's Markov Blanket
+		SlimFactor* targetFactor = factorGraph->getFactorAt(targetID);
+		targetFactor->mergedMB[regID] = 0;
+
+		edgeMap[regID][targetID] = 1;
+	}
+
+	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
+	for(int i = 0; i < factorGraph->getFactorCnt(); i++)
+	{
+		SlimFactor* factor = factorGraph->getFactorAt(i);
+
+		// Delete old potential
+		if (factor->potFunc != NULL) {
+			delete factor->potFunc;
+			factor->potFunc = NULL;
+		}
+
+		if (factor->mergedMB.size() == 0) {
+			factor->potFunc = potManager->createPotential(factor->fId);
+			continue;
+		}
+
+		vector<int> parentIDs;
+		for(auto iter = factor->mergedMB.begin(); iter != factor->mergedMB.end(); iter++) {
+			parentIDs.push_back(iter->first);
+		}
+
+		factor->potFunc = potManager->createPotential(factor->fId, parentIDs);
+	}
 }
 
 double
@@ -611,6 +734,11 @@ MetaLearner::clearFoldSpecData()
 		delete sharedParentDistances;
 		sharedParentDistances = nullptr;
 	}
+	for (auto iter = moduleIndegree.begin(); iter != moduleIndegree.end(); iter++) {
+		delete iter->second;
+	}
+	moduleIndegree.clear();
+	regulatorModuleOutdegree.clear();
 }
 
 int
@@ -681,8 +809,10 @@ int
 MetaLearner::getPredictionError_CrossValid(int foldid)
 {
 	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
+
 	char foldoutDirName[1024];
-	sprintf(foldoutDirName,"%s/fold%d",outputDirName,foldid);
+	sprintf(foldoutDirName, "%s/fold%d", outputDirName, foldid);
+
 	INTINTMAP& testSet=evidenceManager->getTestSet();
 	map<int,double> varPLL;
 	for(INTINTMAP_ITER dIter=testSet.begin();dIter!=testSet.end();dIter++)
@@ -1245,6 +1375,9 @@ MetaLearner::redefineModules(int currFold)
 	hc.cluster(newModules, clusterThreshold, correlationDistances, sharedParentDistances);
 
 	// Clear out any data representing the old module assignments
+	for (auto iter = moduleGeneSet.begin(); iter != moduleGeneSet.end(); iter++) {
+		delete iter->second;
+	}
 	moduleGeneSet.clear();
 	geneModuleID.clear();
 	regulatorModuleOutdegree.clear();
@@ -1395,417 +1528,6 @@ MetaLearner::initDistances()
 	// Initially we have no edges, so no nodes share a parent, and all distances are 1.
 	sharedParentDistances = new Matrix(varCount, varCount);
 	sharedParentDistances->setAllValues(1);
-}
-
-int
-MetaLearner::writeCheckpointMetadata(int iter, bool notConvergedVal)
-{
-    char aFName[1024];
-    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
-
-    ofstream outFile(aFName);
-    outFile << "iter " << iter << endl;
-    outFile << "notConverged " << notConvergedVal << endl;
-    outFile.close();
-
-    return 0;
-}
-
-bool
-MetaLearner::readCheckpointMetadata(int& iter, bool& notConvergedVal)
-{
-    char aFName[1024];
-    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
-
-    ifstream inFile(aFName);
-
-    if (!inFile.is_open())
-    {
-        cerr << "Error: could not open checkpoint file: " << aFName << endl;
-        return false;
-    }
-
-    string label;
-    inFile >> label >> iter;
-    inFile >> label >> notConvergedVal;
-    inFile.close();
-
-    return true;
-}
-
-int 
-MetaLearner::writePLLScore()
-{
-	if (currPLL == NULL) {
-		return -1;
-	}
-
-    char aFName[1024];
-    sprintf(aFName, "%s/pll.txt", foldoutDirName);
-
-    ofstream outFile(aFName);
-
-	// Force maximum double precision to prevent truncation
-    outFile << std::setprecision(std::numeric_limits<double>::max_digits10);
-
-	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-    for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++) {
-        Variable* var = varSet[vIter->first];
-        if (geneModuleID.find(var->getName()) == geneModuleID.end()) {
-			continue;
-		}
-        outFile << var->getName() << "\t" << (*currPLL)[vIter->first] << endl;
-    }
-    outFile.close();
-    return 0;
-}
-
-double 
-MetaLearner::loadInitPLLScore()
-{
-    char aFName[1024];
-    sprintf(aFName, "%s/pll.txt", foldoutDirName);
-
-    ifstream inFile(aFName);
-
-	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-
-	if (currPLL != NULL) {
-		delete currPLL;
-	}
-	currPLL = new unordered_map<int, double>;
-
-    double initScore = 0;
-	char buffer[1024];
-
-    while (inFile.good())
-    {
-        inFile.getline(buffer, 1023);
-        if (strlen(buffer) <= 0) 
-		{
-			continue;
-		}
-        char* tok = strtok(buffer, "\t");
-        int tokCnt = 0;
-        Variable* v = NULL;
-        double val = 0;
-        while (tok != NULL)
-        {
-            if (tokCnt == 0) 
-			{ 
-				int vid = varManager->getVarID(tok); 
-				v = varSet[vid]; 
-			}
-            else 
-			{ 
-				val = atof(tok); 
-			}
-            tok = strtok(NULL, "\t");
-            tokCnt++;
-        }
-        (*currPLL)[v->getID()] = val;
-        initScore += val;
-    }
-    return initScore;
-}
-
-int 
-MetaLearner::writeLastUpdate()
-{
-    char aFName[1024];
-    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
-
-    ofstream outFile(aFName);
-
-	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-    for (auto vIter = varSet.begin(); vIter != varSet.end(); vIter++)
-    {
-        Variable* var = varSet[vIter->first];
-        if (geneModuleID.find(var->getName()) == geneModuleID.end())
-		{
-            continue;
-		}
-        outFile << var->getName() << "\t" << variableStatus[var->getName()] << endl;
-    }
-    outFile.close();
-    return 0;
-}
-
-int 
-MetaLearner::loadLastUpdate()
-{
-    char aFName[1024];
-    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
-
-    ifstream inFile(aFName);
-
-	char buffer[1024];
-    unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-
-	while (inFile.good())
-    {
-        inFile.getline(buffer, 1023);
-        if (strlen(buffer) <= 0) 
-		{
-			continue;
-		}
-        char* tok = strtok(buffer, "\t");
-        int tokCnt = 0;
-        Variable* var = NULL;
-        int titer = 0;
-        while (tok != NULL)
-        {
-            if (tokCnt == 0) 
-			{ 
-				int vid = varManager->getVarID(tok); 
-				var = varSet[vid]; 
-			}
-            else 
-			{ 
-				titer = atoi(tok); 
-			}
-            tok = strtok(NULL, "\t");
-            tokCnt++;
-        }
-        variableStatus[var->getName()] = titer;
-    }
-    return 0;
-}
-
-int 
-MetaLearner::doTar()
-{
-    char tarCmd[1024];
-    sprintf(tarCmd, "tar czf %s.tar.gz %s", foldoutDirName, foldoutDirName);
-    system(tarCmd);
-    return 0;
-}
-
-int
-MetaLearner::readCheckpointModuleMembership()
-{
-	// Clear previous degree distributions
-	moduleGeneSet.clear(); 
-	geneModuleID.clear();
-
-	char aFName[1024];
-    sprintf(aFName, "%s/modules.txt", foldoutDirName);
-	ifstream inFile(aFName);
-	if (!inFile.is_open())
-	{
-		std::cerr << "Error: could not open checkpoint module file: " << aFName << std::endl;
-		return -1;
-	}
-	
-    char buffer[1024];
-    int largestModuleID = -1;
-
-    // Read clustered modules from modules.txt
-    while(inFile.good())
-    {
-        inFile.getline(buffer,1023);
-        if(strlen(buffer)<=0)
-        {
-            continue;
-        }
-
-        string geneName;
-        int moduleID = -1;
-
-        int tokCnt = 0;
-        char* tok = strtok(buffer,"\t");
-        while(tok != NULL)
-        {
-            if(tokCnt == 0)
-            {
-                geneName.append(tok);
-            }
-            else if(tokCnt == 1)
-            {
-                moduleID = atoi(tok);
-            }
-            tok = strtok(NULL,"\t");
-            tokCnt++;
-        }
-        if(moduleID > largestModuleID)
-        {
-            largestModuleID = moduleID;
-        }
-
-        map<string,int>* geneSet = NULL;
-        if(moduleGeneSet.find(moduleID) == moduleGeneSet.end())
-        {
-            geneSet = new map<string,int>;
-            moduleGeneSet[moduleID] = geneSet;
-        }
-        else
-        {
-            geneSet = moduleGeneSet[moduleID];
-        }
-        (*geneSet)[geneName] = 0;
-        geneModuleID[geneName] = moduleID;
-    }
-    inFile.close();
-
-    // Recreate singleton modules (for parentless genes) that were not written to modules.txt
-	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-    int genesWithNoNeighborsCount = 0;
-    for(auto vIter = varSet.begin(); vIter != varSet.end(); vIter++)
-    {
-        Variable* v = vIter->second;
-        string geneName = v->getName();
-        if(geneModuleID.find(geneName) != geneModuleID.end())
-        {
-            continue;
-        }
-        largestModuleID++;
-        map<string,int>* newModule = new map<string,int>;
-        (*newModule)[geneName] = 0;
-        moduleGeneSet[largestModuleID] = newModule;
-        geneModuleID[geneName] = largestModuleID;
-        genesWithNoNeighborsCount++;
-    }
-    cout << "Recovered " << genesWithNoNeighborsCount << " parentless genes not present in modules.txt" << endl;
-    cout << "Total modules after recovery: " << moduleGeneSet.size() << endl;
-    return 0;
-}
-
-int
-MetaLearner::populateGraphsFromFile()
-{
-	// Clear previous degree distributions
-	moduleIndegree.clear();
-	regulatorModuleOutdegree.clear();
-
-	char aFName[1024];
-    sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSize);
-	ifstream inFile(aFName);
-	if (!inFile.is_open())
-	{
-		std::cerr << "Error: could not open checkpoint graph file: " << aFName << std::endl;
-		return -1;
-	}
-	
-	char buffer[1024];
-	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
-
-	// Parse edges and track degrees
-	while(inFile.good())
-	{	
-		inFile.getline(buffer,1023);
-		if(strlen(buffer)<=0)
-		{
-			continue;
-		}
-		char* tok=strtok(buffer,"\t");
-		int tokCnt=0;
-		Variable* u=NULL; // source variable
-		Variable* v=NULL; // target variable
-		while(tok!=NULL)
-		{
-			if(tokCnt==0) // source node
-			{
-				int vid=varManager->getVarID(tok);
-				if (vid < 0)
-				{
-					break;
-				}
-				u=varSet[vid];
-			}
-			else if(tokCnt==1) // target node
-			{
-				int vid=varManager->getVarID(tok);
-				if (vid < 0)
-				{
-					break;
-				}
-				v=varSet[vid];
-			}
-			tok=strtok(NULL,"\t");
-			tokCnt++;
-		}
-		if (u == NULL || v == NULL)
-		{
-			continue;
-		}
-
-		// Track in-degree counts for the module containing the destination variable 'v'
-		int mID=geneModuleID[v->getName()];
-		unordered_map<string, int>* currIndegree=NULL;
-		if(moduleIndegree.find(mID)==moduleIndegree.end())
-		{
-			currIndegree = new unordered_map<string, int>;
-			moduleIndegree[mID]=currIndegree;
-		}
-		else
-		{
-			currIndegree=moduleIndegree[mID];
-		}
-
-		// Increment in-degree for source 'u' pointing into module 'mID'
-		if(currIndegree->find(u->getName())==currIndegree->end())
-		{
-			(*currIndegree)[u->getName()]=1;
-		}
-		else
-		{	
-			(*currIndegree)[u->getName()]=(*currIndegree)[u->getName()]+1;
-		}
-
-		// Track overall out-degree count for the regulator variable 'u'
-		if(regulatorModuleOutdegree.find(u->getName())==regulatorModuleOutdegree.end())
-		{
-			regulatorModuleOutdegree[u->getName()]=1;
-		}
-		else
-		{
-			regulatorModuleOutdegree[u->getName()]=regulatorModuleOutdegree[u->getName()]+1;
-		}
-
-		// Update the Factor Graph: Add source to target gene's Markov Blanket
-		SlimFactor* sFactor=factorGraph->getFactorAt(u->getID());
-		SlimFactor* dFactor=factorGraph->getFactorAt(v->getID());
-		dFactor->mergedMB[sFactor->fId]=0;
-
-		// Record the unique edge path string in the global edge map
-		edgeMap[u->getID()][v->getID()] = 1;
-	}
-
-	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
-	for(int f=0;f<factorGraph->getFactorCnt();f++)
-	{
-		SlimFactor* sFactor=factorGraph->getFactorAt(f);
-
-		// Safely clear old potential objects to prevent memory leaks
-		if (sFactor->potFunc != NULL)
-		{
-			delete sFactor->potFunc;
-			sFactor->potFunc = NULL;
-		}
-
-		if (sFactor->mergedMB.size() == 0)
-		{
-			sFactor->potFunc = potManager->createPotential(sFactor->fId);
-			continue;
-		}
-
-		vector<int> parentIDs;
-		for(auto mIter=sFactor->mergedMB.begin();mIter!=sFactor->mergedMB.end();mIter++)
-		{
-			parentIDs.push_back(mIter->first);
-		}
-
-		Potential* restoredPot = potManager->createPotential(sFactor->fId, parentIDs);
-
-		if (restoredPot == NULL) {
-			sFactor->potFunc = potManager->createPotential(sFactor->fId);
-		} else {
-			sFactor->potFunc = restoredPot;
-		}
-	}
-
-	inFile.close();
-	return 0;
 }
 
 void

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -48,9 +48,9 @@ MetaLearner::setShouldLoadCheckpoint(bool shouldLoadCheckpointVal)
 }
 
 void
-MetaLearner::setMaxFactorSize_Approx(int aVal)
+MetaLearner::setMaxFactorSize(int aVal)
 {
-	maxFactorSizeApprox=aVal;
+	maxFactorSize=aVal;
 }
 
 void
@@ -448,7 +448,6 @@ void
 MetaLearner::start(int currFold)
 {
 	sprintf(foldoutDirName, "%s/fold%d", outputDirName, currFold);
-	int maxNumRegs = maxFactorSizeApprox - 1;
 
 	int iter = 0;
 	bool notConverged=true;
@@ -476,7 +475,7 @@ MetaLearner::start(int currFold)
 
 		// populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
 		cout << "Read networks..." << endl;
-		populateGraphsFromFile(maxFactorSizeApprox);
+		populateGraphsFromFile();
 
 		currGlobalScore = loadInitPLLScore(); 
 
@@ -514,7 +513,7 @@ MetaLearner::start(int currFold)
 			}
 
 			MetaMove nextMove;
-			if (!getNextMove(maxNumRegs, varID, nextMove)) {
+			if (!getNextMove(varID, nextMove)) {
 				cout <<"   No move found " << v->getName() << endl;
 				varID++;
 				continue;
@@ -536,7 +535,7 @@ MetaLearner::start(int currFold)
 		}
 
 		scorePremodule = currGlobalScore;
-		dumpAllGraphs(maxFactorSizeApprox, currFold);
+		dumpAllGraphs(currFold);
 
 		// Checkpointing
 		writeCheckpointMetadata(iter, notConverged);
@@ -789,10 +788,11 @@ MetaLearner::getPredictionError_CrossValid(int foldid)
 }
 
 bool
-MetaLearner::getNextMove(int maxNumRegs, int vID, MetaMove& outMove)
+MetaLearner::getNextMove(int vID, MetaMove& outMove)
 {
 	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	Variable* v = varSet[vID];
+	int maxNumRegs = maxFactorSize - 1;
 
 	if(geneModuleID.find(v->getName()) == geneModuleID.end()) {
 		return false;
@@ -1030,16 +1030,15 @@ MetaLearner::makeMove(MetaMove& nextMove, int currIteration)
 	}
 }
 
-int
-MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid)
+void
+MetaLearner::dumpAllGraphs(int foldid)
 {
-	unordered_map<int, Variable*>& varSet=varManager->getVariableSet();
 	char aFName[1024];
-	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxFactorSizeApprox);
+	sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSize);
 	ofstream oFile(aFName);
+	unordered_map<int, Variable*>& varSet=varManager->getVariableSet();
 	factorGraph->dumpVarMB(oFile, varSet);
 	oFile.close();
-	return 0;
 }
 
 void
@@ -1668,14 +1667,14 @@ MetaLearner::readCheckpointModuleMembership()
 }
 
 int
-MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
+MetaLearner::populateGraphsFromFile()
 {
 	// Clear previous degree distributions
 	moduleIndegree.clear();
 	regulatorModuleOutdegree.clear();
 
 	char aFName[1024];
-    sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSizeApprox);
+    sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSize);
 	ifstream inFile(aFName);
 	if (!inFile.is_open())
 	{

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -313,7 +313,7 @@ MetaLearner::readModuleMembership(const char* aFName)
 		geneModuleID[geneName]=moduleID;
 	}
 	inFile.close();
-	
+
 	return 0;
 }
 
@@ -475,6 +475,8 @@ MetaLearner::doCrossValidation(int foldCnt)
 
 		getPredictionError_CrossValid(f);
 		clearFoldSpecData();
+		// for multiple folds there is leakage: at the start of a new fold, moduleGeneSet is never reset and prev fold's modules are used in initPhysicalDegree
+		// for multiple folds there is leakage: at the start of a new fold, geneModuleID is never reset prev fold's modules are used in getNextMove, makeMove, getModuleContribLogistic
 	}
 	gsl_rng_free(r);
 
@@ -492,10 +494,14 @@ MetaLearner::start(int f)
 	int iter = 0;
 	int rseed=getpid();
 	bool notConverged=true;
+	bool loadedMetadata = false;
 	if(shouldLoad)
 	{
-		readCheckpointMetadata(iter, rseed, notConverged);
-		iter++;
+		loadedMetadata = readCheckpointMetadata(iter, rseed, notConverged);
+		if (loadedMetadata)
+		{
+			iter++;
+		}
 	}
 	rnd=gsl_rng_alloc(gsl_rng_default);
 	gsl_rng_set(rnd,rseed);
@@ -506,7 +512,7 @@ MetaLearner::start(int f)
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad) //********
+	if (shouldLoad && loadedMetadata) //********
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -1489,7 +1495,7 @@ MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVa
     return 0;
 }
 
-int
+bool
 MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
 {
     char aFName[1024];
@@ -1497,14 +1503,19 @@ MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConverged
 
     ifstream inFile(aFName);
 
+    if (!inFile.is_open())
+    {
+        cerr << "Error: could not open checkpoint file: " << aFName << endl;
+        return false;
+    }
+
     string label;
     inFile >> label >> iter;
     inFile >> label >> randseed;
     inFile >> label >> notConvergedVal;
-
     inFile.close();
 
-    return 0;
+    return true;
 }
 
 int 

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -5,8 +5,8 @@
 #include <sys/timeb.h>
 #include <sys/time.h>
 #include <time.h>
-#include <iomanip> // new
-#include <limits> // new
+#include <iomanip>
+#include <limits>
 
 #include "Error.H"
 #include "Variable.H"
@@ -28,7 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
-	shouldLoad = false; // checkpointing
+	shouldLoadCheckpoint = false;
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -44,25 +44,22 @@ MetaLearner::~MetaLearner()
 {
 }
 
-int
-MetaLearner::setShouldLoad(bool shouldLoadVal) // checkpointing
+void
+MetaLearner::setShouldLoadCheckpoint(bool shouldLoadCheckpointVal)
 {
-	shouldLoad = shouldLoadVal;
-	return 0;
+	shouldLoadCheckpoint = shouldLoadCheckpointVal;
 }
 
-int
+void
 MetaLearner::setMaxFactorSize_Approx(int aVal)
 {
 	maxFactorSizeApprox=aVal;
-	return 0;
 }
 
-int
+void
 MetaLearner::setBeta1(double aval)
 {
 	beta1=aval;
-	return 0;
 }
 
 int
@@ -85,7 +82,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior config file path incorrect or file cannot be opened: " << aFName << std::endl;
-		exit(-1);
+		return Error::DATAFILE_ERR;
     }
 
 	char buffer[1024];
@@ -120,28 +117,32 @@ MetaLearner::setPriorGraph_All(const char* aFName)
 		}
 		betamap[gname] = gbeta;
 		map<string,map<string,double>*>* priorGraph = new map<string,map<string,double>*>();
-		setPriorGraph(fname.c_str(),*priorGraph);
+		int status = setPriorGraph(fname.c_str(), *priorGraph);
+		if(status != Error::SUCCESS)
+		{
+			std::cerr << "Error: failed to load prior graph for " << gname << " from " << fname << std::endl;
+			delete priorGraph;
+			return status;
+		}
 		priorgraphmap[gname] = priorGraph;
 	}
 	inFile.close();
-	return 0;
+	return Error::SUCCESS;
 }
 
-int
+void
 MetaLearner::setBeta_Motif(double aval)
 {
 	beta_motif=aval;
-	return 0;
 }
 
-int
+void
 MetaLearner::setConvergenceThreshold(double aVal)
 {
 	convThreshold=aVal;
-	return 0;
 }
 
-int
+void
 MetaLearner::setRestrictedList(const char* aFName)
 {
 	strcpy(restrictedFName,aFName);
@@ -162,51 +163,44 @@ MetaLearner::setRestrictedList(const char* aFName)
 	}
 	inFile.close();
 	std::cout << "Number of regulators read: " << count << std::endl;
-	return 0;
 }
 
 
-int
+void
 MetaLearner::setPreRandomizeSplit()
 {
 	preRandomizeSplit=true;
-	return 0;
 }
 
-int
+void
 MetaLearner::setGlobalEvidenceManager(EvidenceManager* anEvMgr)
 {
 	evidenceManager=anEvMgr;
-	return 0;
 }
 
-int
+void
 MetaLearner::setVariableManager(VariableManager* aPtr)
 {
 	varManager=aPtr;
-	return 0;
 }
 
-int
+void
 MetaLearner::setOutputDirName(const char* dirPath)
 {
 	strcpy(outputDirName,dirPath);
-	return 0;
 }
 
-int
+void
 MetaLearner::setClusteringThreshold(double aVal)
 {
 	clusterThreshold=aVal;
-	return 0;
 }
 
 
-int
+void
 MetaLearner::setSpecificFold(int fid)
 {
 	specificFold=fid;
-	return 0;
 }
 
 int
@@ -216,7 +210,7 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior file path incorrect or file cannot be opened: " << aFName << std::endl;
-		exit(-1);
+		return Error::DATAFILE_ERR;
     }
 
 	char buffer[1024];
@@ -262,14 +256,13 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
 		(*tgtSet)[tgtName]=edgeStrength;
 	}
 	inFile.close();
-	return 0;
+	return Error::SUCCESS;
 }
 
-int
+void
 MetaLearner::setRandom(bool flag)
 {
 	random=flag;
-	return 0;
 }
 
 int
@@ -430,7 +423,6 @@ int
 MetaLearner::doCrossValidation(int foldCnt)
 {
 	gsl_rng* r=gsl_rng_alloc(gsl_rng_default);
-	rnd=gsl_rng_alloc(gsl_rng_default);
 
 	evidenceManager->setFoldCnt(foldCnt);
 	evidenceManager->splitData(0);
@@ -480,7 +472,6 @@ MetaLearner::doCrossValidation(int foldCnt)
 	}
 	gsl_rng_free(r);
 
-	gsl_rng_free(rnd);
 	return 0;
 }
 
@@ -492,27 +483,23 @@ MetaLearner::start(int f)
 	int maxNumRegs = maxFactorSizeApprox-1; // max num of regulators a gene can have
 
 	int iter = 0;
-	int rseed=getpid();
 	bool notConverged=true;
 	bool loadedMetadata = false;
-	if(shouldLoad)
+	if(shouldLoadCheckpoint)
 	{
-		loadedMetadata = readCheckpointMetadata(iter, rseed, notConverged);
+		loadedMetadata = readCheckpointMetadata(iter, notConverged);
 		if (loadedMetadata)
 		{
 			iter++;
 		}
 	}
-	rnd=gsl_rng_alloc(gsl_rng_default);
-	gsl_rng_set(rnd,rseed);
-	cout << "Random seed: " << rseed << endl;
 
 	initEdgePriorMeta_All(); // populates edgepriormap
 	initEdgeSet(); // populates edgeMap, edgePresenceProb (unused), varNeighborhoodPrior, potentials
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad && loadedMetadata) // checkpointing
+	if (shouldLoadCheckpoint && loadedMetadata)
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -581,10 +568,11 @@ MetaLearner::start(int f)
 		scorePremodule=currGlobalScore;
 		dumpAllGraphs(maxFactorSizeApprox,f);
 
-		writeCheckpointMetadata(iter, rseed, notConverged); // checkpointing
-		writePLLScore(); // checkpointing
-		writeLastUpdate(); // checkpointing
-		doTar(); // checkpointing
+		// checkpointing:
+		writeCheckpointMetadata(iter, notConverged);
+		writePLLScore();
+		writeLastUpdate();
+		doTar();
 
 		iter++;
 	}
@@ -1090,7 +1078,7 @@ MetaLearner::makeMove(MetaMove* nextMove, int currIteration)
 }
 
 int
-MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter argument
+MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid)
 {
 	VSET& varSet=varManager->getVariableSet();
 	char aFName[1024];
@@ -1500,14 +1488,13 @@ MetaLearner::initCorrelationDistances()
 // checkpointing additions
 
 int
-MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)
+MetaLearner::writeCheckpointMetadata(int iter, bool notConvergedVal)
 {
     char aFName[1024];
     sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
 
     ofstream outFile(aFName);
     outFile << "iter " << iter << endl;
-    outFile << "randseed " << randseed << endl;
     outFile << "notConverged " << notConvergedVal << endl;
     outFile.close();
 
@@ -1515,7 +1502,7 @@ MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVa
 }
 
 bool
-MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
+MetaLearner::readCheckpointMetadata(int& iter, bool& notConvergedVal)
 {
     char aFName[1024];
     sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
@@ -1530,7 +1517,6 @@ MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConverged
 
     string label;
     inFile >> label >> iter;
-    inFile >> label >> randseed;
     inFile >> label >> notConvergedVal;
     inFile.close();
 
@@ -1551,7 +1537,7 @@ MetaLearner::writePLLScore()
 	INTDBLMAP* plls = currPLL;
 
 	// Force maximum double precision to prevent truncation
-    outFile << std::setprecision(std::numeric_limits<double>::max_digits10); // new
+    outFile << std::setprecision(std::numeric_limits<double>::max_digits10);
 
     for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
     {

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -498,6 +498,8 @@ MetaLearner::start(int currFold)
 		cout << "Beginning regulator identification of iter " << iter << endl;
 
 		int varID = 0;
+		int skippedVarCount = 0;
+		int noMoveCount = 0;
 		double scorePremodule = currGlobalScore;
 
 		while(varID < varSet.size()) {
@@ -507,14 +509,14 @@ MetaLearner::start(int currFold)
 			// If 5 iterations have passed without finding a score improving parent, then skip.
 			int lastiter = variableStatus[v->getName()];
 			if((iter - lastiter) >= 5) {
-				cout <<"   Skipping gene " << v->getName() << "; no parents added in last 5 iters." << endl;
+				skippedVarCount++;
 				varID++;
 				continue;
 			}
 
 			MetaMove nextMove;
 			if (!getNextMove(varID, nextMove)) {
-				cout <<"   No move found " << v->getName() << endl;
+				noMoveCount++;
 				varID++;
 				continue;
 			}
@@ -526,6 +528,8 @@ MetaLearner::start(int currFold)
 			varID++;
 		}
 		cout << "   Finished identifying regulators with score " << currGlobalScore << endl;
+		cout << "   Skipped target count: " << skippedVarCount << endl;
+		cout << "   No move found count: " << noMoveCount << endl;
 
 		notConverged = (currGlobalScore - scorePremodule) > convThreshold;
 

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -85,6 +85,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior config file path incorrect or file cannot be opened: " << aFName << std::endl;
+		exit(-1);
     }
 
 	char buffer[1024];
@@ -215,6 +216,7 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior file path incorrect or file cannot be opened: " << aFName << std::endl;
+		exit(-1);
     }
 
 	char buffer[1024];
@@ -525,7 +527,7 @@ MetaLearner::start(int f)
 	}
 	else
 	{
-		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree
+		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
 
 		for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
 		{
@@ -1104,6 +1106,24 @@ MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter ar
 int
 MetaLearner::initPhysicalDegree()
 {
+	// Early exit: no module can pass hit>4, so entire function is a no-op
+    bool anyLargeModule = false;
+    for (auto& m : moduleGeneSet) {
+        if (m.second->size() > 4) {
+            anyLargeModule = true;
+            break;
+        }
+    }
+    if (!anyLargeModule) {
+        cout << "Skipping initPhysicalDegree: all modules have <=4 genes (hit>4 can never be satisfied)" << endl;
+        return 0;
+    }
+	// if (moduleGeneSet.size() == geneModuleID.size()) // Early exit only for all singleton modules
+	// {
+	// 	cout << "Skipping initPhysicalDegree: singleton modules" << endl;
+	// 	return 0;
+	// }
+
 	for(map<int,map<string,int>*>::iterator mIter=moduleGeneSet.begin();mIter!=moduleGeneSet.end();mIter++)
 	{
 		map<string,int>* indegree=NULL;
@@ -1170,6 +1190,7 @@ MetaLearner::initPhysicalDegree()
 			}
 		}
 	}
+
 	return 0;
 }
 

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -5,6 +5,8 @@
 #include <sys/timeb.h>
 #include <sys/time.h>
 #include <time.h>
+#include <iomanip> // new
+#include <limits> // new
 
 #include "Error.H"
 #include "Variable.H"
@@ -26,6 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
+	shouldLoad = false; //********
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -39,6 +42,13 @@ MetaLearner::MetaLearner()
 
 MetaLearner::~MetaLearner()
 {
+}
+
+int
+MetaLearner::setShouldLoad(bool shouldLoadVal) //********
+{
+	shouldLoad = shouldLoadVal;
+	return 0;
 }
 
 int
@@ -303,6 +313,7 @@ MetaLearner::readModuleMembership(const char* aFName)
 		geneModuleID[geneName]=moduleID;
 	}
 	inFile.close();
+	
 	return 0;
 }
 
@@ -477,26 +488,46 @@ MetaLearner::start(int f)
 	currFold=f;
 	sprintf(foldoutDirName,"%s/fold%d",outputDirName,f);
 	int maxNumRegs = maxFactorSizeApprox-1; // max num of regulators a gene can have
-	rnd=gsl_rng_alloc(gsl_rng_default);
+
+	int iter = 0;
 	int rseed=getpid();
+	bool notConverged=true;
+	if(shouldLoad)
+	{
+		readCheckpointMetadata(iter, rseed, notConverged);
+		iter++;
+	}
+	rnd=gsl_rng_alloc(gsl_rng_default);
 	gsl_rng_set(rnd,rseed);
 	cout << "Random seed: " << rseed << endl;
-	initEdgePriorMeta_All();
-	initEdgeSet();
-	initPhysicalDegree();
+
+	initEdgePriorMeta_All(); // populates edgepriormap
+	initEdgeSet(); // populates edgeMap, edgePresenceProb (unused), varNeighborhoodPrior, potentials
 
 	VSET& varSet=varManager->getVariableSet();
-
-	for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
+	double currGlobalScore=0;
+	if (shouldLoad) //********
 	{
-		Variable *var = vIter->second;
-		variableStatus[var->getName()] = 0;
+		cout << "Read modules..." << endl;
+		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
+
+		cout << "Read networks..." << endl;
+		populateGraphsFromFile(maxFactorSizeApprox); // populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
+
+		currGlobalScore = loadInitPLLScore(); 
+		loadLastUpdate(); // populates variableStatus
+	}
+	else
+	{
+		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree
+
+		for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
+		{
+			variableStatus[vIter->second->getName()] = 0;
+		}
+		currGlobalScore = getInitPLLScore();
 	}
 
-	double currGlobalScore=getInitPLLScore();
-
-	int iter=0;
-	bool notConverged=true;
 	while(notConverged && iter<50)
 	{
 		cout << "Beginning regulator identification of iter " << iter << endl;
@@ -540,9 +571,16 @@ MetaLearner::start(int f)
 			cout << "   Network not converged; score improvement of " << (currGlobalScore-scorePremodule) << ". Redefining modules." << endl;
 			redefineModules();
 		}
-		iter++;
+
 		scorePremodule=currGlobalScore;
-		dumpAllGraphs(maxNumRegs,f,iter);
+		dumpAllGraphs(maxFactorSizeApprox,f);
+
+		writeCheckpointMetadata(iter, rseed, notConverged); //********
+		writePLLScore(); //********
+		writeLastUpdate(); //********
+		doTar(); //********
+
+		iter++;
 	}
 
 	cout <<"Final Score " << currGlobalScore << endl;
@@ -645,7 +683,7 @@ MetaLearner::initEdgeSet()
 			{
 				initPrior=1-1e-6;
 			}
-			edgePresenceProb[edgeKey]=initPrior;
+			edgePresenceProb[edgeKey]=initPrior; // this is never used...
 			if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
 			{
 				varNeighborhoodPrior[vIter->first]=log(1-initPrior);
@@ -1046,11 +1084,11 @@ MetaLearner::makeMove(MetaMove* nextMove, int currIteration)
 }
 
 int
-MetaLearner::dumpAllGraphs(int maxNumRegs,int foldid,int iter)
+MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter argument
 {
 	VSET& varSet=varManager->getVariableSet();
 	char aFName[1024];
-	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxNumRegs+1);
+	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxFactorSizeApprox);
 	ofstream oFile(aFName);
 	factorGraph->dumpVarMB(oFile,varSet);
 	oFile.close();
@@ -1336,8 +1374,8 @@ MetaLearner::redefineModules()
 	}
 	modFile.close();
 
-	// For any genes with no neighbors, create single gene modules
-	cout << "   Number of singleton modules: " << genesWithNoNeighbors.size() << endl;
+	// For any genes with no neighbors, create single-gene modules
+	cout << "   Number of parentless genes: " << genesWithNoNeighbors.size() << endl;
 	for(map<string,int>::iterator gIter=genesWithNoNeighbors.begin();gIter!=genesWithNoNeighbors.end();gIter++)
 	{
 		largestModuleID++;
@@ -1431,4 +1469,416 @@ MetaLearner::initCorrelationDistances()
 			correlationDistances->setValue(cc, j, i);
 		}
 	}
+}
+
+
+// ******** checkpointing additions
+
+int
+MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
+
+    ofstream outFile(aFName);
+    outFile << "iter " << iter << endl;
+    outFile << "randseed " << randseed << endl;
+    outFile << "notConverged " << notConvergedVal << endl;
+    outFile.close();
+
+    return 0;
+}
+
+int
+MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
+
+    ifstream inFile(aFName);
+
+    string label;
+    inFile >> label >> iter;
+    inFile >> label >> randseed;
+    inFile >> label >> notConvergedVal;
+
+    inFile.close();
+
+    return 0;
+}
+
+int 
+MetaLearner::writePLLScore()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/pll.txt", foldoutDirName);
+    ofstream outFile(aFName);
+    VSET& varSet = varManager->getVariableSet();
+	if (currPLL == NULL)
+	{
+		return -1;
+	}
+	INTDBLMAP* plls = currPLL;
+
+	// Force maximum double precision to prevent truncation
+    outFile << std::setprecision(std::numeric_limits<double>::max_digits10); // new
+
+    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* var = varSet[vIter->first];
+        if (geneModuleID.find(var->getName()) == geneModuleID.end())
+            continue;
+        outFile << var->getName() << "\t" << (*plls)[vIter->first] << endl;
+    }
+    outFile.close();
+    return 0;
+}
+
+double 
+MetaLearner::loadInitPLLScore()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/pll.txt", foldoutDirName);
+    ifstream inFile(aFName);
+    char buffer[1024];
+
+    VSET& varSet = varManager->getVariableSet();
+    INTDBLMAP* plls = new INTDBLMAP;
+	if (currPLL != NULL)
+	{
+		delete currPLL;
+	}
+	currPLL = plls;
+
+    double initScore = 0;
+
+    while (inFile.good())
+    {
+        inFile.getline(buffer, 1023);
+        if (strlen(buffer) <= 0) 
+		{
+			continue;
+		}
+        char* tok = strtok(buffer, "\t");
+        int tokCnt = 0;
+        Variable* v = NULL;
+        double val = 0;
+        while (tok != NULL)
+        {
+            if (tokCnt == 0) 
+			{ 
+				int vid = varManager->getVarID(tok); 
+				v = varSet[vid]; 
+			}
+            else 
+			{ 
+				val = atof(tok); 
+			}
+            tok = strtok(NULL, "\t");
+            tokCnt++;
+        }
+        (*plls)[v->getID()] = val;
+        initScore += val;
+    }
+    return initScore;
+}
+
+int 
+MetaLearner::writeLastUpdate()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+    ofstream outFile(aFName);
+    VSET& varSet = varManager->getVariableSet();
+    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* var = varSet[vIter->first];
+        if (geneModuleID.find(var->getName()) == geneModuleID.end())
+		{
+            continue;
+		}
+        outFile << var->getName() << "\t" << variableStatus[var->getName()] << endl;
+    }
+    outFile.close();
+    return 0;
+}
+
+int 
+MetaLearner::loadLastUpdate()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+    ifstream inFile(aFName);
+    char buffer[1024];
+    VSET& varSet = varManager->getVariableSet();
+    while (inFile.good())
+    {
+        inFile.getline(buffer, 1023);
+        if (strlen(buffer) <= 0) 
+		{
+			continue;
+		}
+        char* tok = strtok(buffer, "\t");
+        int tokCnt = 0;
+        Variable* v = NULL;
+        int titer = 0;
+        while (tok != NULL)
+        {
+            if (tokCnt == 0) 
+			{ 
+				int vid = varManager->getVarID(tok); 
+				v = varSet[vid]; 
+			}
+            else 
+			{ 
+				titer = atoi(tok); 
+			}
+            tok = strtok(NULL, "\t");
+            tokCnt++;
+        }
+        variableStatus[v->getName()] = titer;
+    }
+    return 0;
+}
+
+int 
+MetaLearner::doTar()
+{
+    char tarCmd[1024];
+    sprintf(tarCmd, "tar czf %s.tar.gz %s", foldoutDirName, foldoutDirName);
+    system(tarCmd);
+    return 0;
+}
+
+int
+MetaLearner::readCheckpointModuleMembership()
+{
+	// Clear previous degree distributions
+	moduleGeneSet.clear(); 
+	geneModuleID.clear();
+
+	char aFName[1024];
+    sprintf(aFName, "%s/modules.txt", foldoutDirName);
+	ifstream inFile(aFName);
+	if (!inFile.is_open())
+	{
+		std::cerr << "Error: could not open checkpoint module file: " << aFName << std::endl;
+		return -1;
+	}
+	
+    char buffer[1024];
+    int largestModuleID = -1;
+
+    // Read clustered modules from modules.txt
+    while(inFile.good())
+    {
+        inFile.getline(buffer,1023);
+        if(strlen(buffer)<=0)
+        {
+            continue;
+        }
+
+        string geneName;
+        int moduleID = -1;
+
+        int tokCnt = 0;
+        char* tok = strtok(buffer,"\t");
+        while(tok != NULL)
+        {
+            if(tokCnt == 0)
+            {
+                geneName.append(tok);
+            }
+            else if(tokCnt == 1)
+            {
+                moduleID = atoi(tok);
+            }
+            tok = strtok(NULL,"\t");
+            tokCnt++;
+        }
+        if(moduleID > largestModuleID)
+        {
+            largestModuleID = moduleID;
+        }
+
+        map<string,int>* geneSet = NULL;
+        if(moduleGeneSet.find(moduleID) == moduleGeneSet.end())
+        {
+            geneSet = new map<string,int>;
+            moduleGeneSet[moduleID] = geneSet;
+        }
+        else
+        {
+            geneSet = moduleGeneSet[moduleID];
+        }
+        (*geneSet)[geneName] = 0;
+        geneModuleID[geneName] = moduleID;
+    }
+    inFile.close();
+
+    // Recreate singleton modules (for parentless genes) that were not written to modules.txt
+    VSET& varSet = varManager->getVariableSet();
+    int genesWithNoNeighborsCount = 0;
+    for(VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* v = vIter->second;
+        string geneName = v->getName();
+        if(geneModuleID.find(geneName) != geneModuleID.end())
+        {
+            continue;
+        }
+        largestModuleID++;
+        map<string,int>* newModule = new map<string,int>;
+        (*newModule)[geneName] = 0;
+        moduleGeneSet[largestModuleID] = newModule;
+        geneModuleID[geneName] = largestModuleID;
+        genesWithNoNeighborsCount++;
+    }
+    cout << "Recovered " << genesWithNoNeighborsCount << " parentless genes not present in modules.txt" << endl;
+    cout << "Total modules after recovery: " << moduleGeneSet.size() << endl;
+    return 0;
+}
+
+
+int
+MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
+{
+	// Clear previous degree distributions
+	moduleIndegree.clear();
+	regulatorModuleOutdegree.clear();
+	//edgeMap.clear(); we want to keep the initialized edges, and only set them to 1 if we see them.
+
+	char aFName[1024];
+    sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSizeApprox);
+	ifstream inFile(aFName);
+	if (!inFile.is_open())
+	{
+		std::cerr << "Error: could not open checkpoint graph file: " << aFName << std::endl;
+		return -1;
+	}
+	
+	char buffer[1024];
+	VSET& varSet=varManager->getVariableSet();
+
+	// Parse edges and track degrees
+	while(inFile.good())
+	{	
+		inFile.getline(buffer,1023);
+		if(strlen(buffer)<=0)
+		{
+			continue;
+		}
+		char* tok=strtok(buffer,"\t");
+		int tokCnt=0;
+		Variable* u=NULL; // source variable
+		Variable* v=NULL; // target variable
+		while(tok!=NULL)
+		{
+			if(tokCnt==0) // source node
+			{
+				int vid=varManager->getVarID(tok);
+				if (vid < 0)
+				{
+					break;
+				}
+				u=varSet[vid];
+			}
+			else if(tokCnt==1) // target node
+			{
+				int vid=varManager->getVarID(tok);
+				if (vid < 0)
+				{
+					break;
+				}
+				v=varSet[vid];
+			}
+			tok=strtok(NULL,"\t");
+			tokCnt++;
+		}
+		if (u == NULL || v == NULL)
+		{
+			continue;
+		}
+
+		// Track in-degree counts for the module containing the destination variable 'v'
+		int mID=geneModuleID[v->getName()];
+		map<string,int>* currIndegree=NULL;
+		if(moduleIndegree.find(mID)==moduleIndegree.end())
+		{
+			currIndegree=new map<string,int>;
+			moduleIndegree[mID]=currIndegree;
+		}
+		else
+		{
+			currIndegree=moduleIndegree[mID];
+		}
+
+		// Increment in-degree for source 'u' pointing into module 'mID'
+		if(currIndegree->find(u->getName())==currIndegree->end())
+		{
+			(*currIndegree)[u->getName()]=1;
+		}
+		else
+		{	
+			(*currIndegree)[u->getName()]=(*currIndegree)[u->getName()]+1;
+		}
+
+		// Track overall out-degree count for the regulator variable 'u'
+		if(regulatorModuleOutdegree.find(u->getName())==regulatorModuleOutdegree.end())
+		{
+			regulatorModuleOutdegree[u->getName()]=1;
+		}
+		else
+		{
+			regulatorModuleOutdegree[u->getName()]=regulatorModuleOutdegree[u->getName()]+1;
+		}
+
+		// Update the Factor Graph: Add source to target gene's Markov Blanket
+		SlimFactor* sFactor=factorGraph->getFactorAt(u->getID());
+		SlimFactor* dFactor=factorGraph->getFactorAt(v->getID());
+		dFactor->mergedMB[sFactor->fId]=0;
+
+		// Record the unique edge path string in the global edge map
+		string edgeKey;
+		edgeKey.append(u->getName().c_str());
+		edgeKey.append("\t");
+		edgeKey.append(v->getName().c_str());
+		edgeMap[edgeKey]=1;
+	}
+
+	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
+	for(int f=0;f<factorGraph->getFactorCnt();f++)
+	{
+		SlimFactor* sFactor=factorGraph->getFactorAt(f);
+
+		// Safely clear old potential objects to prevent memory leaks
+		if (sFactor->potFunc != NULL)
+		{
+			delete sFactor->potFunc;
+			sFactor->potFunc = NULL;
+		}
+		if (sFactor->mergedMB.size() == 0)
+		{
+			sFactor->potFunc = potManager->createPotential(sFactor->fId);
+			continue;
+		}
+
+		vector<int> parentIDs;
+		for(INTINTMAP_ITER mIter=sFactor->mergedMB.begin();mIter!=sFactor->mergedMB.end();mIter++)
+		{
+			parentIDs.push_back(mIter->first);
+		}
+
+		Potential* restoredPot = NULL;
+		potManager->computeLL(sFactor->fId, parentIDs, evidenceManager->getTrainingSet().size(), &restoredPot);
+		if (restoredPot == NULL)
+		{
+			sFactor->potFunc = potManager->createPotential(sFactor->fId);
+			continue;
+		}
+		sFactor->potFunc = restoredPot;
+	}
+
+	inFile.close();
+	return 0;
 }

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -14,6 +14,7 @@ class PotentialManager;
 class MetaMove;
 class HierarchicalCluster;
 class Matrix;
+class Checkpoint;
 
 class MetaLearner
 {
@@ -40,20 +41,13 @@ class MetaLearner
 
 	private:
 
-		// Checkpointing
-		int writeCheckpointMetadata(int iter, bool notConvergedVal); 
-		bool readCheckpointMetadata(int& iter, bool& notConvergedVal); 
-		int writePLLScore(); 
-		double loadInitPLLScore(); 
-		int writeLastUpdate(); 
-		int loadLastUpdate(); 
-		int doTar(); 
-		int readCheckpointModuleMembership(); 
-		int populateGraphsFromFile();
-
-		void start(int);
+		void start(int fold);
+		void setupFoldState(Checkpoint& checkpoint, int& iter, bool& notConverged, double& globalScore);
+		void setupFoldState(double& globalScore);
+		void restoreCheckpointModules(const unordered_map<string, int>& checkpointGeneModuleIDs);
+		void restoreCheckpointGraph(const vector<pair<string, string>>& checkpointEdges);
+		void writeFoldProgress(int currFold, int iter, bool notConverged, Checkpoint& checkpoint);
 		void initEdgePriorMeta_All();
-		double getInitPLLScore();
 		double getInitPLLScore(int vId);
 		double getPLLScore();
 		double getEdgePrior(int tfID, int targetID);

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -101,7 +101,11 @@ class MetaLearner
 		char foldoutDirName[1024];
 		int specificFold;
 		HierarchicalCluster hc;
+
+		// Used for defining modules, the distance metric based on expression.
 		Matrix* correlationDistances;
+
+		// Used for defining modules, the distance metric based on shared parents.
 		Matrix* sharedParentDistances;
 
 		// Tracks whether two nodes share at least one parent.

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -49,7 +49,7 @@ class MetaLearner
 	// ******** checkpointing additions
 	bool shouldLoad; //********
 	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
-	int readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
+	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
 	int writePLLScore(); //********
 	double loadInitPLLScore(); //********
 	int writeLastUpdate(); //********

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -7,10 +7,6 @@
 
 using namespace std;
 
-//This is gamma map for each variable within each datapoint
-typedef map<int,INTDBLMAP*> DATA_GAMMA_MAP;
-typedef map<int,INTDBLMAP*>::iterator DATA_GAMMA_MAP_ITER;
-
 class VariableManager;
 class EvidenceManager;
 class PotentialManager;
@@ -21,101 +17,97 @@ class Matrix;
 class MetaLearner
 {
 	public:
-	MetaLearner();
-	~MetaLearner();
-	void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
-	void setMaxFactorSize_Approx(int);
-	void setBeta1(double aval);
-	void setBeta_Motif(double bval);
-	int setLambda(double bval);
-	void setConvergenceThreshold(double);
-	void setRestrictedList(const char*);
-	void setPreRandomizeSplit();
-	int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
-	int doCrossValidation(int);
-	void setGlobalEvidenceManager(EvidenceManager*);
-	void setVariableManager(VariableManager*);
-	void setOutputDirName(const char*);
-	void setClusteringThreshold(double);
-	void setSpecificFold(int);
-	int getPredictionError_CrossValid(int);
-	void setRandom(bool);
-	int readModuleMembership(const char*);
-	int setDefaultModuleMembership();
-	int setPriorGraph_All(const char*);
+		MetaLearner();
+		~MetaLearner();
+		void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
+		void setMaxFactorSize_Approx(int);
+		void setBeta1(double aval);
+		void setBeta_Motif(double bval);
+		int setLambda(double bval);
+		void setConvergenceThreshold(double);
+		void setRestrictedList(const char*);
+		void setPreRandomizeSplit();
+		int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
+		int doCrossValidation(int);
+		void setGlobalEvidenceManager(EvidenceManager*);
+		void setVariableManager(VariableManager*);
+		void setOutputDirName(const char*);
+		void setClusteringThreshold(double);
+		void setSpecificFold(int);
+		int getPredictionError_CrossValid(int);
+		void setRandom(bool);
+		int readModuleMembership(const char*);
+		int setDefaultModuleMembership();
+		int setPriorGraph_All(const char*);
 
 	private:
 
-	// checkpointing additions
-	bool shouldLoadCheckpoint; 
-	int writeCheckpointMetadata(int iter, bool notConvergedVal); 
-	bool readCheckpointMetadata(int& iter, bool& notConvergedVal); 
-	int writePLLScore(); 
-	double loadInitPLLScore(); 
-	int writeLastUpdate(); 
-	int loadLastUpdate(); 
-	int doTar(); 
-	int readCheckpointModuleMembership(); 
-	int populateGraphsFromFile(int maxFactorSizeApprox); 
+		// Checkpointing
+		int writeCheckpointMetadata(int iter, bool notConvergedVal); 
+		bool readCheckpointMetadata(int& iter, bool& notConvergedVal); 
+		int writePLLScore(); 
+		double loadInitPLLScore(); 
+		int writeLastUpdate(); 
+		int loadLastUpdate(); 
+		int doTar(); 
+		int readCheckpointModuleMembership(); 
+		int populateGraphsFromFile(int maxFactorSizeApprox); 
 
-	int start(int);
-	int initEdgePriorMeta_All();
-	map <string,double> betamap;
-	map <string,map<int,INTDBLMAP*>*> edgepriormap;
-	map <string,map<string,map<string,double>*>*> priorgraphmap;
+		int start(int);
+		int initEdgePriorMeta_All();
+		double getInitPLLScore();
+		double getInitPLLScore(int vId);
+		double getPLLScore();
+		double getEdgePrior(int tfID, int targetID);
+		int clearFoldSpecData();
+		int initEdgeSet();
+		MetaMove* getNextMove(int currK, int vID);
+		void makeMove(MetaMove* move, int currIteration);
+		void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
+		int dumpAllGraphs(int,int);
+		int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
+		int redefineModules();
+		double getModuleContribLogistic(string& tgtName, string& tfName);
+		int initPhysicalDegree();
+		int getEnrichedTFs(map<string,int>& tfSet,map<string,int>* genes,map<string,map<string,double>*>& edgeSet);
+		void initCorrelationDistances();
 
-	double getInitPLLScore();
-	double getInitPLLScore(int vId);
-	double getPLLScore();
-	double getEdgePrior(int tfID, int targetID);
-	int clearFoldSpecData();
-	int initEdgeSet();
+		FactorGraph* factorGraph;
+		PotentialManager* potManager;
+		EvidenceManager* evidenceManager;
+		VariableManager* varManager;
 
-	MetaMove* getNextMove(int currK, int vID);
-	void makeMove(MetaMove* move, int currIteration);
-	void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
-
-	int dumpAllGraphs(int,int);
-
-	int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
-	int redefineModules();
-	double getModuleContribLogistic(string& tgtName, string& tfName);
-	int initPhysicalDegree();
-	int getEnrichedTFs(map<string,int>& tfSet,map<string,int>* genes,map<string,map<string,double>*>& edgeSet);
-	void initCorrelationDistances();
-
-	FactorGraph* factorGraph;
-	PotentialManager* potManager;
-	EvidenceManager* evidenceManager;
-	VariableManager* varManager;
-
-	int maxFactorSizeApprox;
-	double convThreshold;
-	char restrictedFName[1024];
-	map<string,int> edgeMap;
-	map<string,int> restrictedVarList;
-	INTDBLMAP* currPLL;
-	map<int,double> finalScores;
-	bool preRandomizeSplit;
-	gsl_rng* rnd;
-	char outputDirName[1024];
-	map<string,double> edgePresenceProb;
-	map<int,double> varNeighborhoodPrior;
-	double beta1;
-	double beta_motif;
-	double lambda;
-	bool random;
-	bool randomData;
-	map<int,map<string,int>*> moduleGeneSet;
-	map<string,int> geneModuleID;
-	map<int,map<string,int>*> moduleIndegree;
-	map<string,int> regulatorModuleOutdegree;
-	double clusterThreshold;
-	map<string,int> variableStatus;
-	int currFold;
-	char foldoutDirName[1024];
-	int specificFold;
-	HierarchicalCluster hc;
-	Matrix* correlationDistances;
+		bool shouldLoadCheckpoint;
+		map <string,double> betamap;
+		map <string,map<int,INTDBLMAP*>*> edgepriormap;
+		map <string,map<string,map<string,double>*>*> priorgraphmap;
+		int maxFactorSizeApprox;
+		double convThreshold;
+		char restrictedFName[1024];
+		map<string,int> edgeMap;
+		map<string,int> restrictedVarList;
+		INTDBLMAP* currPLL;
+		map<int,double> finalScores;
+		bool preRandomizeSplit;
+		gsl_rng* rnd;
+		char outputDirName[1024];
+		map<string,double> edgePresenceProb;
+		map<int,double> varNeighborhoodPrior;
+		double beta1;
+		double beta_motif;
+		double lambda;
+		bool random;
+		bool randomData;
+		map<int,map<string,int>*> moduleGeneSet;
+		map<string,int> geneModuleID;
+		map<int,map<string,int>*> moduleIndegree;
+		map<string,int> regulatorModuleOutdegree;
+		double clusterThreshold;
+		map<string,int> variableStatus;
+		int currFold;
+		char foldoutDirName[1024];
+		int specificFold;
+		HierarchicalCluster hc;
+		Matrix* correlationDistances;
 };
 #endif

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -2,6 +2,7 @@
 #define _META_LEARNER_
 
 #include <map>
+#include <unordered_map>
 #include "CommonTypes.H"
 #include "HierarchicalCluster.H"
 
@@ -18,15 +19,14 @@ class MetaLearner
 {
 	public:
 		MetaLearner();
-		~MetaLearner();
 		void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
 		void setMaxFactorSize_Approx(int);
 		void setBeta1(double aval);
 		void setBeta_Motif(double bval);
 		void setConvergenceThreshold(double);
 		void setRestrictedList(const char*);
-		int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
-		int doCrossValidation(int);
+		int initEdgePriorMeta(const string& priorName, map<string, map<string, double>*>& graph, unordered_map<int, unordered_map<int, double>*>& edgePrior);
+		void doCrossValidation(int);
 		void setGlobalEvidenceManager(EvidenceManager*);
 		void setVariableManager(VariableManager*);
 		void setOutputDirName(const char*);
@@ -34,8 +34,8 @@ class MetaLearner
 		void setSpecificFold(int);
 		int getPredictionError_CrossValid(int);
 		void setRandom(bool);
-		int readModuleMembership(const char*);
-		int setDefaultModuleMembership();
+		void readModuleMembership(const char*);
+		void setDefaultModuleMembership();
 		int setPriorGraph_All(const char*);
 
 	private:
@@ -51,57 +51,63 @@ class MetaLearner
 		int readCheckpointModuleMembership(); 
 		int populateGraphsFromFile(int maxFactorSizeApprox); 
 
-		int start(int);
-		int initEdgePriorMeta_All();
+		void start(int);
+		void initEdgePriorMeta_All();
 		double getInitPLLScore();
 		double getInitPLLScore(int vId);
 		double getPLLScore();
 		double getEdgePrior(int tfID, int targetID);
-		int clearFoldSpecData();
+		void clearFoldSpecData();
 		int initEdgeSet();
-		MetaMove* getNextMove(int currK, int vID);
-		void makeMove(MetaMove* move, int currIteration);
-		void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
-		int dumpAllGraphs(int,int);
-		int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
-		int redefineModules();
+		bool getNextMove(int currK, int vID, MetaMove& outMove);
+		void makeMove(MetaMove& move, int currIteration);
+		int dumpAllGraphs(int, int);
+		int setPriorGraph(const char* aFName, map<string, map<string, double>*>& priorGraph);
+		void redefineModules(int currFold);
 		double getModuleContribLogistic(string& tgtName, string& tfName);
-		int initPhysicalDegree();
-		int getEnrichedTFs(map<string,int>& tfSet,map<string,int>* genes,map<string,map<string,double>*>& edgeSet);
-		void initCorrelationDistances();
+		void initPhysicalDegree();
+		void getEnrichedTFs(map<string, int>& tfSet, map<string, int>* genes, map<string, map<string, double>*>& edgeSet);
+		void initDistances();
+		void updateSharedParentDistances();
 
 		FactorGraph* factorGraph;
 		PotentialManager* potManager;
 		EvidenceManager* evidenceManager;
 		VariableManager* varManager;
-
+		
 		bool shouldLoadCheckpoint;
-		map <string,double> betamap;
-		map <string,map<int,INTDBLMAP*>*> edgepriormap;
-		map <string,map<string,map<string,double>*>*> priorgraphmap;
+		map<string, double> betaMap;
+		map<string, unordered_map<int, unordered_map<int, double>*>*> edgePriorMap;
+		map<string, map<string, map<string, double>*>*> priorGraphMap;
 		int maxFactorSizeApprox;
 		double convThreshold;
 		char restrictedFName[1024];
-		map<string,int> edgeMap;
+		unordered_map<int, unordered_map<int, int>> edgeMap;
 		map<string,int> restrictedVarList;
-		INTDBLMAP* currPLL;
-		map<int,double> finalScores;
+		unordered_map<int, double>* currPLL;
+		map<int, double> finalScores;
 		char outputDirName[1024];
-		map<string,double> edgePresenceProb;
-		map<int,double> varNeighborhoodPrior;
+		map<string, double> edgePresenceProb;
+		map<int, double> varNeighborhoodPrior;
 		double beta1;
 		double beta_motif;
 		bool random;
-		map<int,map<string,int>*> moduleGeneSet;
-		map<string,int> geneModuleID;
-		map<int,map<string,int>*> moduleIndegree;
-		map<string,int> regulatorModuleOutdegree;
+		map<int, map<string, int>*> moduleGeneSet;
+		unordered_map<string, int> geneModuleID;
+		unordered_map<int, unordered_map<string, int>*> moduleIndegree;
+		unordered_map<string, int> regulatorModuleOutdegree;
 		double clusterThreshold;
-		map<string,int> variableStatus;
-		int currFold;
+		unordered_map<string, int> variableStatus;
 		char foldoutDirName[1024];
 		int specificFold;
 		HierarchicalCluster hc;
 		Matrix* correlationDistances;
+		Matrix* sharedParentDistances;
+
+		// Tracks whether two nodes share at least one parent.
+		unordered_map<int, unordered_map<int, int>> sharedParents;
+
+		// Var ids of any nodes with a parent added this iteration.
+		vector<int> updatedThisIteration;
 };
 #endif

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,23 +23,23 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
-	int setShouldLoad(bool shouldLoadVal); // checkpointing
-	int setMaxFactorSize_Approx(int);
-	int setBeta1(double aval);
-	int setBeta_Motif(double bval);
+	void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
+	void setMaxFactorSize_Approx(int);
+	void setBeta1(double aval);
+	void setBeta_Motif(double bval);
 	int setLambda(double bval);
-	int setConvergenceThreshold(double);
-	int setRestrictedList(const char*);
-	int setPreRandomizeSplit();
+	void setConvergenceThreshold(double);
+	void setRestrictedList(const char*);
+	void setPreRandomizeSplit();
 	int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
 	int doCrossValidation(int);
-	int setGlobalEvidenceManager(EvidenceManager*);
-	int setVariableManager(VariableManager*);
-	int setOutputDirName(const char*);
-	int setClusteringThreshold(double);
-	int setSpecificFold(int);
+	void setGlobalEvidenceManager(EvidenceManager*);
+	void setVariableManager(VariableManager*);
+	void setOutputDirName(const char*);
+	void setClusteringThreshold(double);
+	void setSpecificFold(int);
 	int getPredictionError_CrossValid(int);
-	int setRandom(bool);
+	void setRandom(bool);
 	int readModuleMembership(const char*);
 	int setDefaultModuleMembership();
 	int setPriorGraph_All(const char*);
@@ -47,9 +47,9 @@ class MetaLearner
 	private:
 
 	// checkpointing additions
-	bool shouldLoad; 
-	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); 
-	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); 
+	bool shouldLoadCheckpoint; 
+	int writeCheckpointMetadata(int iter, bool notConvergedVal); 
+	bool readCheckpointMetadata(int& iter, bool& notConvergedVal); 
 	int writePLLScore(); 
 	double loadInitPLLScore(); 
 	int writeLastUpdate(); 
@@ -75,7 +75,7 @@ class MetaLearner
 	void makeMove(MetaMove* move, int currIteration);
 	void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
 
-	int dumpAllGraphs(int,int); // remove iter argument
+	int dumpAllGraphs(int,int);
 
 	int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
 	int redefineModules();

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -20,7 +20,7 @@ class MetaLearner
 	public:
 		MetaLearner();
 		void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
-		void setMaxFactorSize_Approx(int);
+		void setMaxFactorSize(int);
 		void setBeta1(double aval);
 		void setBeta_Motif(double bval);
 		void setConvergenceThreshold(double);
@@ -49,7 +49,7 @@ class MetaLearner
 		int loadLastUpdate(); 
 		int doTar(); 
 		int readCheckpointModuleMembership(); 
-		int populateGraphsFromFile(int maxFactorSizeApprox); 
+		int populateGraphsFromFile();
 
 		void start(int);
 		void initEdgePriorMeta_All();
@@ -59,9 +59,9 @@ class MetaLearner
 		double getEdgePrior(int tfID, int targetID);
 		void clearFoldSpecData();
 		int initEdgeSet();
-		bool getNextMove(int currK, int vID, MetaMove& outMove);
+		bool getNextMove(int vID, MetaMove& outMove);
 		void makeMove(MetaMove& move, int currIteration);
-		int dumpAllGraphs(int, int);
+		void dumpAllGraphs(int);
 		int setPriorGraph(const char* aFName, map<string, map<string, double>*>& priorGraph);
 		void redefineModules(int currFold);
 		double getModuleContribLogistic(string& tgtName, string& tfName);
@@ -79,7 +79,7 @@ class MetaLearner
 		map<string, double> betaMap;
 		map<string, unordered_map<int, unordered_map<int, double>*>*> edgePriorMap;
 		map<string, map<string, map<string, double>*>*> priorGraphMap;
-		int maxFactorSizeApprox;
+		int maxFactorSize;
 		double convThreshold;
 		char restrictedFName[1024];
 		unordered_map<int, unordered_map<int, int>> edgeMap;

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,7 +23,7 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
-	int setShouldLoad(bool shouldLoadVal); //********
+	int setShouldLoad(bool shouldLoadVal); // checkpointing
 	int setMaxFactorSize_Approx(int);
 	int setBeta1(double aval);
 	int setBeta_Motif(double bval);
@@ -46,17 +46,17 @@ class MetaLearner
 
 	private:
 
-	// ******** checkpointing additions
-	bool shouldLoad; //********
-	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
-	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
-	int writePLLScore(); //********
-	double loadInitPLLScore(); //********
-	int writeLastUpdate(); //********
-	int loadLastUpdate(); //********
-	int doTar(); //********
-	int readCheckpointModuleMembership(); //********
-	int populateGraphsFromFile(int maxFactorSizeApprox); //********
+	// checkpointing additions
+	bool shouldLoad; 
+	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); 
+	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); 
+	int writePLLScore(); 
+	double loadInitPLLScore(); 
+	int writeLastUpdate(); 
+	int loadLastUpdate(); 
+	int doTar(); 
+	int readCheckpointModuleMembership(); 
+	int populateGraphsFromFile(int maxFactorSizeApprox); 
 
 	int start(int);
 	int initEdgePriorMeta_All();

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,10 +23,8 @@ class MetaLearner
 		void setMaxFactorSize_Approx(int);
 		void setBeta1(double aval);
 		void setBeta_Motif(double bval);
-		int setLambda(double bval);
 		void setConvergenceThreshold(double);
 		void setRestrictedList(const char*);
-		void setPreRandomizeSplit();
 		int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
 		int doCrossValidation(int);
 		void setGlobalEvidenceManager(EvidenceManager*);
@@ -88,16 +86,12 @@ class MetaLearner
 		map<string,int> restrictedVarList;
 		INTDBLMAP* currPLL;
 		map<int,double> finalScores;
-		bool preRandomizeSplit;
-		gsl_rng* rnd;
 		char outputDirName[1024];
 		map<string,double> edgePresenceProb;
 		map<int,double> varNeighborhoodPrior;
 		double beta1;
 		double beta_motif;
-		double lambda;
 		bool random;
-		bool randomData;
 		map<int,map<string,int>*> moduleGeneSet;
 		map<string,int> geneModuleID;
 		map<int,map<string,int>*> moduleIndegree;

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,6 +23,7 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
+	int setShouldLoad(bool shouldLoadVal); //********
 	int setMaxFactorSize_Approx(int);
 	int setBeta1(double aval);
 	int setBeta_Motif(double bval);
@@ -44,6 +45,19 @@ class MetaLearner
 	int setPriorGraph_All(const char*);
 
 	private:
+
+	// ******** checkpointing additions
+	bool shouldLoad; //********
+	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
+	int readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
+	int writePLLScore(); //********
+	double loadInitPLLScore(); //********
+	int writeLastUpdate(); //********
+	int loadLastUpdate(); //********
+	int doTar(); //********
+	int readCheckpointModuleMembership(); //********
+	int populateGraphsFromFile(int maxFactorSizeApprox); //********
+
 	int start(int);
 	int initEdgePriorMeta_All();
 	map <string,double> betamap;
@@ -61,7 +75,7 @@ class MetaLearner
 	void makeMove(MetaMove* move, int currIteration);
 	void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
 
-	int dumpAllGraphs(int,int,int);
+	int dumpAllGraphs(int,int); // remove iter argument
 
 	int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
 	int redefineModules();

--- a/common/EvidenceManager.C
+++ b/common/EvidenceManager.C
@@ -11,8 +11,6 @@
 EvidenceManager::EvidenceManager()
 {
 	foldCnt=1;
-	preRandomizeSplit=false;
-	randseed=0;
 }
 
 Error::ErrorCode
@@ -100,9 +98,9 @@ EvidenceManager::randomizeEvidence(gsl_rng* r, VariableManager* vMgr)
 		randEvidenceSet.push_back(evidMap);
 	}
 	//Populate variable wise
-	VSET& variableSet=vMgr->getVariableSet();
+	unordered_map<int, Variable*>& variableSet = vMgr->getVariableSet();
 	int* randInds=new int[trainIndex.size()];
-	for(VSET_ITER vIter=variableSet.begin();vIter!=variableSet.end();vIter++)
+	for(auto vIter=variableSet.begin();vIter!=variableSet.end();vIter++)
 	{
 		//generate a random vector of indices ranging from 0 to evidenceSet.size()-1
 		populateRandIntegers(r,randInds,trainIndex,trainIndex.size());
@@ -155,13 +153,6 @@ EvidenceManager::setFoldCnt(int f)
 }
 
 int
-EvidenceManager::setPreRandomizeSplit()
-{
-	preRandomizeSplit=true;
-	return 0;
-}
-
-int
 EvidenceManager::splitData(int s)
 {
 	int testSetSize=evidenceSet.size()/foldCnt;
@@ -179,38 +170,17 @@ EvidenceManager::splitData(int s)
 	trainIndex.clear();
 	testIndex.clear();
 	int m=0;
-	int* randInds=NULL;
-	if(preRandomizeSplit)
-	{
-		randInds=new int[evidenceSet.size()];
-		//generate a random vector of indices ranging from 0 to evidenceSet.size()-1
-		gsl_rng* r=gsl_rng_alloc(gsl_rng_default);
-		randseed=getpid();
-		gsl_rng_set(r,randseed);
-		populateRandIntegers(r,randInds,evidenceSet.size());
-		gsl_rng_free(r);
-		cout <<"Random seed " << randseed << endl;
-	}
 	for(int i=0;i<evidenceSet.size();i++)
 	{
-		int eInd=i;
-		if(randInds!=NULL)
-		{
-			eInd=randInds[i];
-		}
 		if((m>=testStartIndex) && (m<testEndIndex))
 		{
-			testIndex[eInd]=0;
+			testIndex[i]=0;
 		}
 		else
 		{
-			trainIndex[eInd]=0;
+			trainIndex[i]=0;
 		}
 		m++;
-	}
-	if(preRandomizeSplit)
-	{
-		delete[] randInds;
 	}
 	return 0;
 }
@@ -225,27 +195,6 @@ INTINTMAP&
 EvidenceManager::getTestSet()
 {
 	return testIndex;
-}
-
-int
-EvidenceManager::populateRandIntegers(gsl_rng* r, int* randInds,int size)
-{
-	double step=1.0/(double)size;
-	map<int,int> usedInit;
-	for(int i=0;i<size;i++)
-	{
-		double rVal=gsl_ran_flat(r,0,1);
-		int rind=(int)(rVal/step);
-		while(usedInit.find(rind)!=usedInit.end())
-		{
-			rVal=gsl_ran_flat(r,0,1);
-			rind=(int)(rVal/step);
-		}
-		usedInit[rind]=0;
-		randInds[i]=rind;
-	}
-	usedInit.clear();
-	return 0;
 }
 
 int
@@ -276,24 +225,3 @@ EvidenceManager::populateRandIntegers(gsl_rng* r, int* randInds, INTINTMAP& popu
 	usedInit.clear();
 	return 0;
 }
-
-int
-EvidenceManager::populateRandIntegers(gsl_rng* r, vector<int>& randInds,int size, int subsetsize)
-{
-	double step=1.0/(double)size;
-	map<int,int> usedInit;
-	for(int i=0;i<subsetsize;i++)
-	{
-		double rVal=gsl_ran_flat(r,0,1);
-		int rind=(int)(rVal/step);
-		while(usedInit.find(rind)!=usedInit.end())
-		{
-			rVal=gsl_ran_flat(r,0,1);
-			rind=(int)(rVal/step);
-		}
-		usedInit[rind]=0;
-		randInds.push_back(rind);
-	}
-	return 0;
-}
-

--- a/common/EvidenceManager.H
+++ b/common/EvidenceManager.H
@@ -14,8 +14,8 @@ class Evidence;
 
 //EMAP stores the map of variable ids and their evidence. This corresponds
 //to one line in the datafile
-typedef map<int,Evidence*> EMAP;
-typedef map<int,Evidence*>::iterator EMAP_ITER;
+typedef unordered_map<int,Evidence*> EMAP;
+typedef unordered_map<int,Evidence*>::iterator EMAP_ITER;
 
 typedef vector<EMAP*> EVIDENCE_SET;
 
@@ -34,14 +34,11 @@ class EvidenceManager
 
 		int randomizeEvidence(gsl_rng*, VariableManager*);
 		int setFoldCnt(int);
-		int setPreRandomizeSplit();
 		int splitData(int);
 		INTINTMAP& getTrainingSet();
 		INTINTMAP& getTestSet();
-		int populateRandIntegers(gsl_rng*, vector<int>&,int,int);
 
 	private:
-		int populateRandIntegers(gsl_rng*, int*,int);
 		int populateRandIntegers(gsl_rng* r, int* randInds, INTINTMAP& populateFrom, int size);
 
 		EVIDENCE_SET evidenceSet;
@@ -49,7 +46,5 @@ class EvidenceManager
 		INTINTMAP trainIndex;
 		INTINTMAP testIndex;
 		int foldCnt;
-		bool preRandomizeSplit;
-		int randseed;
 };
 #endif

--- a/common/FactorGraph.C
+++ b/common/FactorGraph.C
@@ -9,20 +9,15 @@
 
 FactorGraph::FactorGraph(VariableManager* vMgr)
 {
-	map<int,Variable*>& variableSet=vMgr->getVariableSet();
-	int vCnt=variableSet.size();
-	// cout << " Number of factors " << vCnt << endl;
-
-	int factorIndex=0;
-	for(map<int,Variable*>::iterator vIter=variableSet.begin();vIter!=variableSet.end();vIter++)
+	unordered_map<int, Variable*>& variableSet = vMgr->getVariableSet();
+	for(auto vIter = variableSet.begin(); vIter != variableSet.end(); vIter++)
 	{
 		SlimFactor* sFactor=new SlimFactor;
 		sFactor->vIds=new int[1];
 		sFactor->vIds[0]=vIter->first;
 		sFactor->vCnt=1;
-		sFactor->fId=factorIndex;
+		sFactor->fId=vIter->first;
 		factorSet[sFactor->fId]=sFactor;
-		factorIndex++;
 	}
 }
 
@@ -51,7 +46,7 @@ FactorGraph::getFactorAt(int fid)
 }
 
 int
-FactorGraph::dumpVarMB(ofstream& oFile,VSET& variableSet)
+FactorGraph::dumpVarMB(ofstream& oFile, unordered_map<int, Variable*>& variableSet)
 {
 	for(map<int,SlimFactor*>::iterator aIter=factorSet.begin();aIter!=factorSet.end();aIter++)
 	{
@@ -60,10 +55,9 @@ FactorGraph::dumpVarMB(ofstream& oFile,VSET& variableSet)
 		{
 			break;
 		}
-		INTDBLMAP& regWts=sFactor->potFunc->getWeights();
-		for(INTDBLMAP_ITER mIter=regWts.begin();mIter!=regWts.end();mIter++)
-		{
-			oFile << variableSet[mIter->first]->getName() << "\t" << variableSet[sFactor->vIds[0]]->getName() << "\t" << mIter->second << endl;
+		vector<pair<int, double>>& regWts = sFactor->potFunc->getWeights();
+		for (const auto& weight : regWts) {
+			oFile << variableSet[weight.first]->getName() << "\t" << variableSet[sFactor->vIds[0]]->getName() << "\t" << weight.second << endl;
 		}
 	}
 	return 0;

--- a/common/FactorGraph.H
+++ b/common/FactorGraph.H
@@ -17,7 +17,7 @@ class FactorGraph
 
 		int getFactorCnt();
 		SlimFactor* getFactorAt(int);
-		int dumpVarMB(ofstream&, VSET&);
+		int dumpVarMB(ofstream&, unordered_map<int, Variable*>&);
 
 	private:
 		map<int,SlimFactor*> factorSet;

--- a/common/Potential.C
+++ b/common/Potential.C
@@ -1,29 +1,42 @@
 #include <iostream>
 #include <math.h>
+#include <algorithm>
 #include "Evidence.H"
 #include "Potential.H"
 
 #include "gsl/gsl_randist.h"
 
-Potential::Potential(int factorID, double variance, double bias, INTDBLMAP& weights)
+Potential::Potential(int factorID, double variance, double bias, unordered_map<int, double>& weights)
 {
 	this->factorID = factorID;
 	this->variance = variance;
 	this->bias = bias;
-	this->weights = weights;
+
+	this->weights.reserve(weights.size());
+
+	// Copy over the weights
+	for (auto iter = weights.begin(); iter != weights.end(); iter++) {
+		this->weights.emplace_back(iter->first, iter->second);
+	}
+
+	// Sort the weights by var ID. Keeping these sorted makes it easier to find the intersection of parents between two potentials,
+	// which we do when defining modules.
+	sort(this->weights.begin(), this->weights.end(), [](const pair<int, double>& a, const pair<int, double>& b) {
+		return a.first < b.first;
+	});
 }
 
-INTDBLMAP&
+vector<pair<int, double>>&
 Potential::getWeights()
 {
 	return weights;
 }
 
 double
-Potential::getExpectation(map<int,Evidence*>* evidenceSet)
+Potential::getExpectation(unordered_map<int, Evidence*>* evidenceSet)
 {
 	double mean=0;
-	for(INTDBLMAP_ITER aIter=weights.begin();aIter!=weights.end();aIter++)
+	for(auto aIter = weights.begin(); aIter != weights.end(); aIter++)
 	{
 		if(evidenceSet->find(aIter->first)==evidenceSet->end())
 		{
@@ -38,10 +51,9 @@ Potential::getExpectation(map<int,Evidence*>* evidenceSet)
 }
 
 double
-Potential::evaluateProbabilityDensity(map<int,Evidence*>* evidMap)
+Potential::evaluateProbabilityDensity(unordered_map<int, Evidence*>* evidMap)
 {
-	if(evidMap->find(factorID)==evidMap->end())
-	{
+	if(evidMap->find(factorID)==evidMap->end()) {
 		cerr <<"Fatal error! No variable assignment for " << factorID << endl;
 		exit(-1);
 	}

--- a/common/Potential.H
+++ b/common/Potential.H
@@ -2,6 +2,7 @@
 #define _POTENTIAL
 
 #include <fstream>
+#include <unordered_map>
 #include "gsl/gsl_randist.h"
 #include "CommonTypes.H"
 #include "Matrix.H"
@@ -19,22 +20,22 @@ class Variable;
 class Potential
 {
 	public:
-		Potential(int factorID, double variance, double bias, INTDBLMAP& weights);
+		Potential(int factorID, double variance, double bias, unordered_map<int, double>& weights);
 
-		INTDBLMAP& getWeights();
+		vector<pair<int, double>>& getWeights();
 
 		// Returns the expected value of the factor variable, given the values
 		// of the conditioning variables.
-		double getExpectation(map<int,Evidence*>*);
+		double getExpectation(unordered_map<int, Evidence*>*);
 
 		// Evaluates the conditional probability density at the provided factor
 		// variable value, given the provided values of the conditioning variables.
-		double evaluateProbabilityDensity(map<int,Evidence*>*);
+		double evaluateProbabilityDensity(unordered_map<int, Evidence*>*);
 
 	private:
 		int factorID;
 		double variance;
 		double bias;
-		INTDBLMAP weights;
+		vector<pair<int, double>> weights;
 };
 #endif

--- a/common/PotentialManager.C
+++ b/common/PotentialManager.C
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cstring>
 #include <math.h>
+#include <unordered_map>
 
 #include "CommonTypes.H"
 #include "Error.H"
@@ -11,32 +12,19 @@
 
 PotentialManager::PotentialManager()
 {
-	ludecomp=NULL;
-	perm=NULL;
-	globalCovariances=nullptr;
+	globalCovariances = nullptr;
 }
 
 PotentialManager::~PotentialManager()
 {
-	if(ludecomp!=NULL)
-	{
-		gsl_matrix_free(ludecomp);
-	}
-	if(perm!=NULL)
-	{
-		gsl_permutation_free(perm);
-	}
-	if(globalCovariances!=nullptr)
-	{
+	if (globalCovariances != nullptr) {
 		delete globalCovariances;
 	}
 }
 
-int
-PotentialManager::init(EvidenceManager* evMgr, bool randomData, vector<int>& varIDs)
+int PotentialManager::init(EvidenceManager* evMgr, bool randomData, vector<int>& varIDs)
 {
-	if (globalCovariances != nullptr)
-	{
+	if (globalCovariances != nullptr) {
 		delete globalCovariances;
 	}
 
@@ -135,89 +123,230 @@ PotentialManager::init(EvidenceManager* evMgr, bool randomData, vector<int>& var
 		}
 	}
 
-	ludecomp = gsl_matrix_alloc(MAXFACTORSIZE_ALLOC, MAXFACTORSIZE_ALLOC);
-	perm = gsl_permutation_alloc(MAXFACTORSIZE_ALLOC);
-
 	return 0;
 }
 
-Potential*
-PotentialManager::createPotential(int factorID)
+Potential* PotentialManager::createPotential(int factorID)
 {
 	int varCount = globalMeans.size();
 	double variance = globalCovariances->getValue(factorID, factorID);
 	double bias = globalMeans[factorID];
-	INTDBLMAP weights;
+	unordered_map<int, double> weights;
 	return new Potential(factorID, variance, bias, weights);
 }
 
-double
-PotentialManager::computeLL(int factorID, vector<int>& parentIDs, int sampleSize, Potential** newPot)
+void PotentialManager::computeLLs(int factorID, int sampleSize, vector<int>& existingParents, vector<int>&candidateParents, unordered_map<int, double>&scores) {
+
+	if (existingParents.size() == 0) {
+		computeSingleParentLLs(factorID, sampleSize, candidateParents, scores);
+		return;
+	}
+
+	// In order to compute likelihood, we need the variance of the factor conditioned upon existing parents and the candidate parent.
+	// We use the following framing
+	// A : Factor
+	// B : existing parents
+	// C : candidate parent
+	// Var(A | B, C) = Var(A | B) - Cov(AC | B) * Var(C | B)^-1 * Cov(CA | B)
+	// Var (A | B) = Var(A) - Cov(AB) * Var(B)^-1 * Cov(BA)
+	// Var (C | B) = Var(C) - Cov(CB) * Var(B)^-1 * Cov(BC)
+	// Cov (AC | B) = Cov(AC) - Cov(AB) * Var(B)^-1 * Cov(BC)
+
+	// This allows us to precompute Var(A | B), Var(B)^-1, and Cov(AB) * Var(B)^-1, because they don't rely on C. Since we only add a single
+	// candidate parent at a time, the per candidate work doesn't require any matrix inverts, only scalar and vector multiplication.
+
+	int parentCount = existingParents.size();
+
+	// Var(A)
+	double factorVariance = globalCovariances->getValue(factorID, factorID);
+
+	// Cov(AB)
+	gsl_vector* existingParentMarginalVariances = gsl_vector_alloc(parentCount);
+
+	// Cov(BB)
+	gsl_matrix* existingParentCovariances = gsl_matrix_alloc(parentCount, parentCount);
+
+	for (int i = 0; i < parentCount; i++) {
+		int varAID = existingParents[i];
+		double marginalCovariance = globalCovariances->getValue(factorID, varAID);
+		gsl_vector_set(existingParentMarginalVariances, i, marginalCovariance);
+
+		for (int j = i; j < parentCount; j++) {
+			int varBID = existingParents[j];
+			double covariance = globalCovariances->getValue(varAID, varBID);
+			gsl_matrix_set(existingParentCovariances, i, j, covariance);
+			gsl_matrix_set(existingParentCovariances, j, i, covariance);
+		}
+	}
+
+	gsl_permutation* permutation = gsl_permutation_alloc(parentCount);
+
+	int signum=0;
+	gsl_linalg_LU_decomp(existingParentCovariances, permutation, &signum);
+
+	// Var(B)^-1
+	gsl_matrix* parentCovInverse = gsl_matrix_alloc(parentCount, parentCount);
+	gsl_linalg_LU_invert(existingParentCovariances, permutation, parentCovInverse);
+
+	gsl_matrix_free(existingParentCovariances);
+	gsl_permutation_free(permutation);
+
+	// Cov(AB) * Var(B)^-1
+	gsl_vector* prod = gsl_vector_alloc(parentCount);
+	gsl_blas_dgemv(CblasTrans, 1, parentCovInverse, existingParentMarginalVariances, 0, prod);
+
+	// Cov(AB) * Var(B)^-1 * Cov(BA)
+	double dot = 0.0;
+	gsl_blas_ddot(prod, existingParentMarginalVariances, &dot);
+
+	// Var(A|B)
+	double existingConditionalVariance = factorVariance - dot;
+
+	gsl_vector_free(existingParentMarginalVariances);
+
+	for (int i = 0; i < candidateParents.size(); i++) {
+		int candidateID = candidateParents[i];
+
+		// Var(C)
+		double candidateVariance = globalCovariances->getValue(candidateID, candidateID);
+
+		// Cov(BC)
+		gsl_vector* candidateMarginalVariances = gsl_vector_alloc(parentCount);
+
+		for (int i = 0; i < parentCount; i++) {
+			int varAID = existingParents[i];
+			double marginalCovariance = globalCovariances->getValue(candidateID, varAID);
+			gsl_vector_set(candidateMarginalVariances, i, marginalCovariance);
+		}
+
+		// Cov(BC) * Var(B)^-1
+		gsl_vector* candidateProd = gsl_vector_alloc(parentCount);
+		gsl_blas_dgemv(CblasTrans, 1, parentCovInverse, candidateMarginalVariances, 0, candidateProd);
+
+		// Cov(BC) * Var(B)^-1 * Cov(CB)
+		double dot = 0.0;
+		gsl_blas_ddot(candidateProd, candidateMarginalVariances, &dot);
+
+		// Var(C|B)
+		double candidateConditionalVariance = candidateVariance - dot;
+
+		if (candidateConditionalVariance < 1e-10) {
+			continue;
+		}
+
+		// Cov(AC)
+		double candidateFactorCovariance = globalCovariances->getValue(candidateID, factorID);
+
+		// Cov(AB) * Var(B)^-1 * Cov(BC)
+		dot = 0.0;
+		gsl_blas_ddot(prod, candidateMarginalVariances, &dot);
+
+		gsl_vector_free(candidateProd);
+		gsl_vector_free(candidateMarginalVariances);
+
+		// Cov(AC | B)
+		double factorAndCandidateConditionalCov = candidateFactorCovariance - dot;
+
+		// Var(A | B, C)
+		double finalVariance = existingConditionalVariance - factorAndCandidateConditionalCov * factorAndCandidateConditionalCov / candidateConditionalVariance;
+
+		if (finalVariance < 1e-5) {
+			finalVariance = 1e-5;
+		}
+
+		if(isnan(finalVariance) || isinf(finalVariance)) {
+			continue;
+		}
+
+		scores[candidateID] = -0.5 * ((sampleSize - 1) + sampleSize * log(2 * PI) + sampleSize * log(finalVariance));
+	}
+
+	gsl_matrix_free(parentCovInverse);
+	gsl_vector_free(prod);
+}
+
+// Computes a gaussian log likelihood of factor id conditioned upon a single parent, for each candidate parent.
+// The single parent case is broken out into a separate function because it can be done with fast scalar arithmetic.
+void PotentialManager::computeSingleParentLLs(int factorID, int sampleSize, vector<int>&candidateParents, unordered_map<int, double>&scores) {
+
+	double factorVariance = globalCovariances->getValue(factorID, factorID);
+
+	for (int i = 0; i < candidateParents.size(); i++) {
+		int candidateID = candidateParents[i];
+
+		double candidateVariance = globalCovariances->getValue(candidateID, candidateID);
+
+		if (candidateVariance < 1e-10) {
+			continue;
+		}
+
+		double factorCandidateCov = globalCovariances->getValue(factorID, candidateID);
+		double finalVariance = factorVariance - factorCandidateCov * factorCandidateCov / candidateVariance;
+
+		if (finalVariance < 1e-5) {
+			finalVariance = 1e-5;
+		}
+
+		if(isnan(finalVariance) || isinf(finalVariance)) {
+			continue;
+		}
+
+		scores[candidateID] = -0.5 * ((sampleSize - 1) + sampleSize * log(2 * PI) + sampleSize * log(finalVariance));
+	}
+}
+
+Potential* PotentialManager::createPotential(int factorID, vector<int>& parentIDs)
 {
+	int parentCount = parentIDs.size();
 	double variance = globalCovariances->getValue(factorID, factorID);
 	double bias = globalMeans[factorID];
-	INTDBLMAP weights;
-
-	int parentCount = parentIDs.size();
 
 	// Start by collecting a matrix of all the covariances of the conditioning variables,
 	// and the marginal variances of the conditioning variables.
 
-	Matrix *parentCovariances = new Matrix(parentCount, parentCount);
-	Matrix *parentMarginalVariances = new Matrix(1, parentCount);
+	gsl_matrix* parentCovariances = gsl_matrix_alloc(parentCount, parentCount);
+	gsl_vector* parentMarginalVariances = gsl_vector_alloc(parentCount);
 
-	for (int i = 0; i < parentCount; i++)
-	{
+	for (int i = 0; i < parentCount; i++) {
 		int varAID = parentIDs[i];
-		double factorCovariance = globalCovariances->getValue(factorID, varAID);
-		parentMarginalVariances->setValue(factorCovariance, 0, i);
+		double marginalCovariance = globalCovariances->getValue(factorID, varAID);
+		gsl_vector_set(parentMarginalVariances, i, marginalCovariance);
 
-		for (int j = i; j < parentCount; j++)
-		{
+		for (int j = i; j < parentCount; j++) {
 			int varBID = parentIDs[j];
 			double covariance = globalCovariances->getValue(varAID, varBID);
-			parentCovariances->setValue(covariance, i, j);
-			parentCovariances->setValue(covariance, j, i);
+			gsl_matrix_set(parentCovariances, i, j, covariance);
+			gsl_matrix_set(parentCovariances, j, i, covariance);
 		}
 	}
 
 	// Compute the final values for the variance of the conditional gaussian,
 	// plus the regression parameters for the mean of the conditional guassian.
 
-	Matrix* parentCovInverse = parentCovariances->invMatrix(ludecomp, perm);
-	Matrix* prod = parentMarginalVariances->multiplyMatrix(parentCovInverse);
+	gsl_vector* x = gsl_vector_alloc(parentCount);
 
-	for (int i = 0; i < parentCount; i++)
-	{
+	gsl_permutation* permutation = gsl_permutation_alloc(parentCount);
+
+	int signum = 0;
+	gsl_linalg_LU_decomp(parentCovariances, permutation, &signum);
+
+	gsl_linalg_LU_solve(parentCovariances, permutation, parentMarginalVariances, x);
+
+	unordered_map<int, double> weights;
+	for (int i = 0; i < parentCount; i++) {
 		int vID = parentIDs[i];
-		double aVal = prod->getValue(0, i);
-		double bVal = parentMarginalVariances->getValue(0, i);
+		double aVal = gsl_vector_get(x, i);
+		double bVal = gsl_vector_get(parentMarginalVariances, i);
 		double cVal = globalMeans[vID];
 		weights[vID] = aVal;
 		variance -= aVal * bVal;
 		bias -= cVal * aVal;
 	}
 
-	delete prod;
-	delete parentMarginalVariances;
-	delete parentCovariances;
-	delete parentCovInverse;
+	gsl_vector_free(x);
+	gsl_vector_free(parentMarginalVariances);
+	gsl_permutation_free(permutation);
+	gsl_matrix_free(parentCovariances);
 
-	if(variance < 1e-5)
-	{
-		variance = 1e-5;
-	}
-
-	// If the variance is invalid, then we don't want to attempt adding this edge,
-	// so we should just bail out before computing the LL
-	if(isnan(variance) || isinf(variance))
-	{
-		return -1;
-	}
-
-	// Now that the conditional Gaussian params are computed, we can create the potential.
-	*newPot = new Potential(factorID, variance, bias, weights);
-
-	// Finally, compute the conditional log likelihood.
-	return -0.5 * ((sampleSize - 1) + sampleSize * log(2 * PI) + sampleSize * log(variance));
+	return new Potential(factorID, variance, bias, weights);
 }

--- a/common/PotentialManager.H
+++ b/common/PotentialManager.H
@@ -20,14 +20,15 @@ class PotentialManager
 		// Creates a Potential of a single variable.
 		Potential* createPotential(int factorID);
 
-		// Computes the conditional Gaussian log likelihood of the factor's assignments
-		// conditioned upon its parents. It also creates a Potential representing this conditional
-		// Gaussian PDF.
-		double computeLL(int factorID, vector<int>& parentIDs, int sampleSize, Potential** newPot);
+		// Creates a Potential conditioned on a set of parents.
+		Potential* createPotential(int factorID, vector<int>& parentIDs);
+
+		// Computes a Gaussian log likelihood for the factor conditioned upon its existing parents and each candidate parent.
+		void computeLLs(int factorID, int sampleSize, vector<int>& existingParents, vector<int>&candidateParents, unordered_map<int, double>&scores);
 
 	private:
-		gsl_matrix* ludecomp;
-		gsl_permutation* perm;
+		void computeSingleParentLLs(int factorID, int sampleSize, vector<int>&candidateParents, unordered_map<int, double>&scores);
+
 		vector<double> globalMeans;
 		Matrix *globalCovariances;
 };

--- a/common/SlimFactor.C
+++ b/common/SlimFactor.C
@@ -5,6 +5,11 @@
 
 SlimFactor::SlimFactor()
 {
+	vIds=NULL;
+	vCnt=0;
+	fId=-1;
+	canonicalParams=NULL;
+	potFunc=NULL;
 	refCnt=0;
 }
 
@@ -15,6 +20,8 @@ SlimFactor::SlimFactor(int fSize)
 	//secondPId=-1;
 	//confidence=0;
 	fId=-1;
+	canonicalParams=NULL;
+	potFunc=NULL;
 	refCnt=0;
 }
 

--- a/common/SlimFactor.C
+++ b/common/SlimFactor.C
@@ -175,21 +175,3 @@ SlimFactor::thresholdToOne(double threshold)
 	}
 	return 0;
 }
-
-int 
-SlimFactor::showFactor(ostream& oFile, VSET& variableSet, bool newLine)
-{
-	for(int i=0;i<vCnt;i++)
-	{
-		if(i>0)
-		{
-			oFile << "-";
-		}
-		oFile << variableSet[vIds[i]]->getName();
-	}
-	if(newLine)
-	{
-		oFile << endl;
-	}
-	return 0;
-}

--- a/common/SlimFactor.H
+++ b/common/SlimFactor.H
@@ -21,7 +21,6 @@ class SlimFactor
 		int genMBSubsets(int);
 		int thresholdToOne(double);
 		bool allEntriesInsignificant();
-		int showFactor(ostream&, VSET& variableSet, bool newLine=true);
 		int fId;
 		int* vIds;
 		int vCnt;

--- a/common/Variable.H
+++ b/common/Variable.H
@@ -9,9 +9,6 @@ using namespace std;
 
 class Variable;
 
-typedef map<int,Variable*> VSET;
-typedef map<int,Variable*>::iterator VSET_ITER;
-
 class Variable
 {
 	public:

--- a/common/VariableManager.C
+++ b/common/VariableManager.C
@@ -6,15 +6,6 @@
 #include "Variable.H"
 #include "VariableManager.H"
 
-
-VariableManager::VariableManager()
-{
-}
-
-VariableManager::~VariableManager()
-{
-}
-
 //Reads the schema of the variables
 
 Error::ErrorCode
@@ -58,15 +49,12 @@ VariableManager::readVariables(const char* aFName)
 }
 
 int
-VariableManager::getVarID(const char* varName)
+VariableManager::getVarID(const string& varKey)
 {
-	string varKey(varName);
-	if(varNameIDMap.find(varKey)==varNameIDMap.end())
-	{
+	if(varNameIDMap.find(varKey)==varNameIDMap.end()) {
 		return -1;
 	}
-	int vId=varNameIDMap[varKey];
-	return vId;
+	return varNameIDMap[varKey];
 }
 
 bool
@@ -76,18 +64,16 @@ VariableManager::isValid(int varID,int varVal)
 	return rVar->isValidValue(varVal);
 }
 
-map<int,Variable*>&
+unordered_map<int, Variable*>&
 VariableManager::getVariableSet()
 {
 	return variableSet;
 }
 
-
 Variable*
 VariableManager::getVariableAt(int vId)
 {
-	if(variableSet.find(vId)==variableSet.end())
-	{
+	if(variableSet.find(vId) == variableSet.end()) {
 		cout << "Illegal variable id " << vId << endl;
 		return NULL;
 	}

--- a/common/VariableManager.H
+++ b/common/VariableManager.H
@@ -2,7 +2,7 @@
 #define _VARIABLE_MANAGER
 
 #include <string>
-#include <map>
+#include <unordered_map>
 
 using namespace std;
 
@@ -11,16 +11,14 @@ class Variable;
 class VariableManager
 {
 	public:
-		VariableManager();
-		~VariableManager();
 		Error::ErrorCode readVariables(const char*);
-		int getVarID(const char*);
+		int getVarID(const string& varName);
 		bool isValid(int,int);
-		map<int,Variable*>& getVariableSet();
+		unordered_map<int, Variable*>& getVariableSet();
 		Variable* getVariableAt(int);
 	private:
-		map<string,int> varNameIDMap;
-		map<int,Variable*> variableSet;
+		unordered_map<string, int> varNameIDMap;
+		unordered_map<int, Variable*> variableSet;
 		int globalVarId;
 };
 #endif


### PR DESCRIPTION
This PR is intended to speed up the performance of Merlin-p. I tested it out using the dataset @livj4711 shared with me, and with these changes the run completes in about an hour and fifteen minutes.

Here are the changes made to achieve that speed up:

**Swapping out map for unordered_map**

In several places, I've replaced usage of map with unordered_map. map is backed by a binary search tree, not a hashmap, and so the time complexity of inserting and accessing from a map is O(logn), whereas unordered_map has constant time access. As a result, anytime we don't rely on being able to iterate the entries in a particular order, we should use an unordered_map instead of a map.

**Exit getEnrichedTFs early for small modules**

Before the first iteration, merlin-p saves a parent mapping based on the prior graphs. As part of building this mapping, we check whether each TF is 'enriched' for each module, which takes quite a long time. Most of this work is unneeded, at least for this dataset, because part of our definition of 'enriched' includes having 4 targets within the module, and this dataset's initial modules has only single variable modules, so no TF can be enriched. I added a check to getEnrichedTFs that returns early if the module has less than 4 variables, so that we don't waste time checking all the targets in this case.

**Cache the shared parent distances**

While redefining modules, at the end of each iteration, we calculate a pairwise distance between each variable based on the shared parents and regression weights. This is a heavy operation due to the high number of pairs, but a good deal of this work can be cached. The distance between two variables only changes from one iteration to another if one of them has a new parent added in that iteration and they share at least one parent. By tracking which nodes share a parent and which have been updated each iteration, we can get by with only updating a small percent of the pairs.

**Compute LL of each candidate parent conditioned upon existing parents, instead of LL of all parents**

This is mathematically identical, but reframing in this way allows us to perform most of the work just once per target, and then a small amount of work per candidate parent.

Previously, for each target we would iterate through all candidate parents. For each candidate, we add it to the set of parents, re-compute LL from scratch, and then remove it from the parent set. This means we compute the LL for many sets of parents that are almost identical, without sharing any work between candidates.

Our LL calculation depends on the variance of our factor conditioned upon the parent set. By re-framing this as Var(factor | existing parents, candidate parent) we can break out part of the work and pre-calculate it, and then share it across all the different candidate calculations.

Previously, we calculated:
Var(factor | all parents) = Var(factor) - Cov(factor, all parents) * Cov(all parents)^-1 * Cov(all parents, factor)

We're replacing that with:
Var(factor | existing parents and candidate) = Var(factor | existing parents) - Cov(factor, candidate | existing parents) * Var (candidate)^-1 * Cov(candidate, factor | existing parents)

This is the same value, but that first term doesn't depend on the candidate, and so it can be precomputed and shared across all the candidate LL calculations. Since the candidate is always just a single variable, the work left to do per candidate is just vector and scalar multiplications. This yields a really significant speed improvement!

**Drawback**

There is a cost to the performance improvements here, in that after applying these changes Merlin-p will require more memory. The new matrix for caching sharedParentDistances will use 10k * 10k * 64 bit = ~800mb of memory. The sharedParents map's size will depend on how many variables have a parent in common, but could be a max of ~400mb (if every variable shared a parent with every other).

If memory is a concern, we could probably come up with ways to cut this cost down while still getting most of the performance benefit. For example, both of these matrixes are symmetric so we could cut the size in half by storing only half of them. Another even bigger target if we wanted to cut down on memory usage would be the distValues matrix in HierarchicalCluster. It reserves space for 20k x 20k doubles, so unless I'm mistaken it's using up about 3gb. 
