### PR TITLE
Checkpointing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 merlin
 example/out_dir/
+example/out_dir*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 merlin
 example/out_dir/
 example/out_dir*
+test/out_dir*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 merlin
 example/out_dir/
-example/out_dir*
-test/out_dir*

--- a/Framework.C
+++ b/Framework.C
@@ -212,7 +212,7 @@ main(int argc, char* argv[])
 		cout <<"MERLIN-P GRN Inference " <<  endl
 			<< "-d gene_expression_file " << endl
 			<< "-k maxfactorsize (default size_of_dataset)" << endl
-			<< "-v cross_validation_cnt [BROKEN FOR >1 FOLDS] (default 1)" << endl
+			<< "-v cross_validation_cnt (default 1)" << endl
 			<< "-l restricted_regulator_fname" << endl
 			<< "-p sparsity_prior (default -5)" << endl
 			<< "-r module_prior (default 4)" << endl

--- a/Framework.C
+++ b/Framework.C
@@ -212,7 +212,7 @@ main(int argc, char* argv[])
 		cout <<"MERLIN-P GRN Inference " <<  endl
 			<< "-d gene_expression_file " << endl
 			<< "-k maxfactorsize (default size_of_dataset)" << endl
-			<< "-v cross_validation_cnt (default 1)" << endl
+			<< "-v cross_validation_cnt [BROKEN FOR >1 FOLDS] (default 1)" << endl
 			<< "-l restricted_regulator_fname" << endl
 			<< "-p sparsity_prior (default -5)" << endl
 			<< "-r module_prior (default 4)" << endl

--- a/Framework.C
+++ b/Framework.C
@@ -110,7 +110,12 @@ Framework::init(int argc, char** argv)
 			}
 			case 'q':
 			{
-				metaLearner.setPriorGraph_All(optarg);
+				int status = metaLearner.setPriorGraph_All(optarg);
+				if(status != Error::SUCCESS)
+				{
+					std::cerr << "Failed: " << Error::getErrorString(status) << std::endl;
+					exit(-1); 
+				}
 				break;
 			}
 			case 'c':
@@ -132,7 +137,7 @@ Framework::init(int argc, char** argv)
 			}
 			case 'a':
 			{
-				metaLearner.setShouldLoad(true);
+				metaLearner.setShouldLoadCheckpoint(true);
 				break;
 			}
 			case '?':

--- a/Framework.C
+++ b/Framework.C
@@ -40,7 +40,7 @@ Framework::init(int argc, char** argv)
 	int optret;
 	opterr=1;
 
-	while((optret=getopt(argc,argv,"o:k:d:v:l:p:r:c:h:f:q:"))!=-1)
+	while((optret=getopt(argc,argv,"o:k:d:v:l:p:r:c:h:f:q:a"))!=-1)
 	{
 		switch(optret)
 		{
@@ -130,6 +130,11 @@ Framework::init(int argc, char** argv)
 				metaLearner.setSpecificFold(atoi(optarg));
 				break;
 			}
+			case 'a':
+			{
+				metaLearner.setShouldLoad(true);
+				break;
+			}
 			case '?':
 			{
 				cerr << "Option error " << optopt << endl;
@@ -215,7 +220,8 @@ main(int argc, char* argv[])
 			<< "-o outputdirectory" << endl
 			<< "-c moduleassignment (default random_partitioning) "<< endl
 			<< "-h hierarchical_clustering_threshold (default 0.6)"<< endl
-			<< "-f specificfold_torun (default is -1)" << endl ;
+			<< "-f specificfold_torun (default is -1)" << endl 
+			<< "-a load_checkpoint (default is false)" << endl ;
 		return 0;
 	}
 	Framework fw;

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -28,7 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
-	shouldLoad = false; //********
+	shouldLoad = false; // checkpointing
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -45,7 +45,7 @@ MetaLearner::~MetaLearner()
 }
 
 int
-MetaLearner::setShouldLoad(bool shouldLoadVal) //********
+MetaLearner::setShouldLoad(bool shouldLoadVal) // checkpointing
 {
 	shouldLoad = shouldLoadVal;
 	return 0;
@@ -477,8 +477,6 @@ MetaLearner::doCrossValidation(int foldCnt)
 
 		getPredictionError_CrossValid(f);
 		clearFoldSpecData();
-		// for multiple folds there is leakage: at the start of a new fold, moduleGeneSet is never reset and prev fold's modules are used in initPhysicalDegree
-		// for multiple folds there is leakage: at the start of a new fold, geneModuleID is never reset prev fold's modules are used in getNextMove, makeMove, getModuleContribLogistic
 	}
 	gsl_rng_free(r);
 
@@ -514,7 +512,7 @@ MetaLearner::start(int f)
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad && loadedMetadata) //********
+	if (shouldLoad && loadedMetadata) // checkpointing
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -583,10 +581,10 @@ MetaLearner::start(int f)
 		scorePremodule=currGlobalScore;
 		dumpAllGraphs(maxFactorSizeApprox,f);
 
-		writeCheckpointMetadata(iter, rseed, notConverged); //********
-		writePLLScore(); //********
-		writeLastUpdate(); //********
-		doTar(); //********
+		writeCheckpointMetadata(iter, rseed, notConverged); // checkpointing
+		writePLLScore(); // checkpointing
+		writeLastUpdate(); // checkpointing
+		doTar(); // checkpointing
 
 		iter++;
 	}
@@ -691,7 +689,7 @@ MetaLearner::initEdgeSet()
 			{
 				initPrior=1-1e-6;
 			}
-			edgePresenceProb[edgeKey]=initPrior; // this is never used...
+			edgePresenceProb[edgeKey]=initPrior;
 			if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
 			{
 				varNeighborhoodPrior[vIter->first]=log(1-initPrior);
@@ -1499,7 +1497,7 @@ MetaLearner::initCorrelationDistances()
 }
 
 
-// ******** checkpointing additions
+// checkpointing additions
 
 int
 MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -313,7 +313,7 @@ MetaLearner::readModuleMembership(const char* aFName)
 		geneModuleID[geneName]=moduleID;
 	}
 	inFile.close();
-	
+
 	return 0;
 }
 
@@ -475,6 +475,8 @@ MetaLearner::doCrossValidation(int foldCnt)
 
 		getPredictionError_CrossValid(f);
 		clearFoldSpecData();
+		// for multiple folds there is leakage: at the start of a new fold, moduleGeneSet is never reset and prev fold's modules are used in initPhysicalDegree
+		// for multiple folds there is leakage: at the start of a new fold, geneModuleID is never reset prev fold's modules are used in getNextMove, makeMove, getModuleContribLogistic
 	}
 	gsl_rng_free(r);
 
@@ -492,10 +494,14 @@ MetaLearner::start(int f)
 	int iter = 0;
 	int rseed=getpid();
 	bool notConverged=true;
+	bool loadedMetadata = false;
 	if(shouldLoad)
 	{
-		readCheckpointMetadata(iter, rseed, notConverged);
-		iter++;
+		loadedMetadata = readCheckpointMetadata(iter, rseed, notConverged);
+		if (loadedMetadata)
+		{
+			iter++;
+		}
 	}
 	rnd=gsl_rng_alloc(gsl_rng_default);
 	gsl_rng_set(rnd,rseed);
@@ -506,7 +512,7 @@ MetaLearner::start(int f)
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad) //********
+	if (shouldLoad && loadedMetadata) //********
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -1489,7 +1495,7 @@ MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVa
     return 0;
 }
 
-int
+bool
 MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
 {
     char aFName[1024];
@@ -1497,14 +1503,19 @@ MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConverged
 
     ifstream inFile(aFName);
 
+    if (!inFile.is_open())
+    {
+        cerr << "Error: could not open checkpoint file: " << aFName << endl;
+        return false;
+    }
+
     string label;
     inFile >> label >> iter;
     inFile >> label >> randseed;
     inFile >> label >> notConvergedVal;
-
     inFile.close();
 
-    return 0;
+    return true;
 }
 
 int 

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -5,8 +5,8 @@
 #include <sys/timeb.h>
 #include <sys/time.h>
 #include <time.h>
-#include <iomanip> // new
-#include <limits> // new
+#include <iomanip>
+#include <limits>
 
 #include "Error.H"
 #include "Variable.H"
@@ -28,7 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
-	shouldLoad = false; // checkpointing
+	shouldLoadCheckpoint = false;
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -44,25 +44,22 @@ MetaLearner::~MetaLearner()
 {
 }
 
-int
-MetaLearner::setShouldLoad(bool shouldLoadVal) // checkpointing
+void
+MetaLearner::setShouldLoadCheckpoint(bool shouldLoadCheckpointVal)
 {
-	shouldLoad = shouldLoadVal;
-	return 0;
+	shouldLoadCheckpoint = shouldLoadCheckpointVal;
 }
 
-int
+void
 MetaLearner::setMaxFactorSize_Approx(int aVal)
 {
 	maxFactorSizeApprox=aVal;
-	return 0;
 }
 
-int
+void
 MetaLearner::setBeta1(double aval)
 {
 	beta1=aval;
-	return 0;
 }
 
 int
@@ -85,7 +82,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior config file path incorrect or file cannot be opened: " << aFName << std::endl;
-		exit(-1);
+		return Error::DATAFILE_ERR;
     }
 
 	char buffer[1024];
@@ -120,28 +117,32 @@ MetaLearner::setPriorGraph_All(const char* aFName)
 		}
 		betamap[gname] = gbeta;
 		map<string,map<string,double>*>* priorGraph = new map<string,map<string,double>*>();
-		setPriorGraph(fname.c_str(),*priorGraph);
+		int status = setPriorGraph(fname.c_str(), *priorGraph);
+		if(status != Error::SUCCESS)
+		{
+			std::cerr << "Error: failed to load prior graph for " << gname << " from " << fname << std::endl;
+			delete priorGraph;
+			return status;
+		}
 		priorgraphmap[gname] = priorGraph;
 	}
 	inFile.close();
-	return 0;
+	return Error::SUCCESS;
 }
 
-int
+void
 MetaLearner::setBeta_Motif(double aval)
 {
 	beta_motif=aval;
-	return 0;
 }
 
-int
+void
 MetaLearner::setConvergenceThreshold(double aVal)
 {
 	convThreshold=aVal;
-	return 0;
 }
 
-int
+void
 MetaLearner::setRestrictedList(const char* aFName)
 {
 	strcpy(restrictedFName,aFName);
@@ -162,51 +163,44 @@ MetaLearner::setRestrictedList(const char* aFName)
 	}
 	inFile.close();
 	std::cout << "Number of regulators read: " << count << std::endl;
-	return 0;
 }
 
 
-int
+void
 MetaLearner::setPreRandomizeSplit()
 {
 	preRandomizeSplit=true;
-	return 0;
 }
 
-int
+void
 MetaLearner::setGlobalEvidenceManager(EvidenceManager* anEvMgr)
 {
 	evidenceManager=anEvMgr;
-	return 0;
 }
 
-int
+void
 MetaLearner::setVariableManager(VariableManager* aPtr)
 {
 	varManager=aPtr;
-	return 0;
 }
 
-int
+void
 MetaLearner::setOutputDirName(const char* dirPath)
 {
 	strcpy(outputDirName,dirPath);
-	return 0;
 }
 
-int
+void
 MetaLearner::setClusteringThreshold(double aVal)
 {
 	clusterThreshold=aVal;
-	return 0;
 }
 
 
-int
+void
 MetaLearner::setSpecificFold(int fid)
 {
 	specificFold=fid;
-	return 0;
 }
 
 int
@@ -216,7 +210,7 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior file path incorrect or file cannot be opened: " << aFName << std::endl;
-		exit(-1);
+		return Error::DATAFILE_ERR;
     }
 
 	char buffer[1024];
@@ -262,14 +256,13 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
 		(*tgtSet)[tgtName]=edgeStrength;
 	}
 	inFile.close();
-	return 0;
+	return Error::SUCCESS;
 }
 
-int
+void
 MetaLearner::setRandom(bool flag)
 {
 	random=flag;
-	return 0;
 }
 
 int
@@ -430,7 +423,6 @@ int
 MetaLearner::doCrossValidation(int foldCnt)
 {
 	gsl_rng* r=gsl_rng_alloc(gsl_rng_default);
-	rnd=gsl_rng_alloc(gsl_rng_default);
 
 	evidenceManager->setFoldCnt(foldCnt);
 	evidenceManager->splitData(0);
@@ -480,7 +472,6 @@ MetaLearner::doCrossValidation(int foldCnt)
 	}
 	gsl_rng_free(r);
 
-	gsl_rng_free(rnd);
 	return 0;
 }
 
@@ -492,27 +483,23 @@ MetaLearner::start(int f)
 	int maxNumRegs = maxFactorSizeApprox-1; // max num of regulators a gene can have
 
 	int iter = 0;
-	int rseed=getpid();
 	bool notConverged=true;
 	bool loadedMetadata = false;
-	if(shouldLoad)
+	if(shouldLoadCheckpoint)
 	{
-		loadedMetadata = readCheckpointMetadata(iter, rseed, notConverged);
+		loadedMetadata = readCheckpointMetadata(iter, notConverged);
 		if (loadedMetadata)
 		{
 			iter++;
 		}
 	}
-	rnd=gsl_rng_alloc(gsl_rng_default);
-	gsl_rng_set(rnd,rseed);
-	cout << "Random seed: " << rseed << endl;
 
 	initEdgePriorMeta_All(); // populates edgepriormap
 	initEdgeSet(); // populates edgeMap, edgePresenceProb (unused), varNeighborhoodPrior, potentials
 
 	VSET& varSet=varManager->getVariableSet();
 	double currGlobalScore=0;
-	if (shouldLoad && loadedMetadata) // checkpointing
+	if (shouldLoadCheckpoint && loadedMetadata)
 	{
 		cout << "Read modules..." << endl;
 		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
@@ -581,10 +568,11 @@ MetaLearner::start(int f)
 		scorePremodule=currGlobalScore;
 		dumpAllGraphs(maxFactorSizeApprox,f);
 
-		writeCheckpointMetadata(iter, rseed, notConverged); // checkpointing
-		writePLLScore(); // checkpointing
-		writeLastUpdate(); // checkpointing
-		doTar(); // checkpointing
+		// checkpointing:
+		writeCheckpointMetadata(iter, notConverged);
+		writePLLScore();
+		writeLastUpdate();
+		doTar();
 
 		iter++;
 	}
@@ -1090,7 +1078,7 @@ MetaLearner::makeMove(MetaMove* nextMove, int currIteration)
 }
 
 int
-MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter argument
+MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid)
 {
 	VSET& varSet=varManager->getVariableSet();
 	char aFName[1024];
@@ -1500,14 +1488,13 @@ MetaLearner::initCorrelationDistances()
 // checkpointing additions
 
 int
-MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)
+MetaLearner::writeCheckpointMetadata(int iter, bool notConvergedVal)
 {
     char aFName[1024];
     sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
 
     ofstream outFile(aFName);
     outFile << "iter " << iter << endl;
-    outFile << "randseed " << randseed << endl;
     outFile << "notConverged " << notConvergedVal << endl;
     outFile.close();
 
@@ -1515,7 +1502,7 @@ MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVa
 }
 
 bool
-MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
+MetaLearner::readCheckpointMetadata(int& iter, bool& notConvergedVal)
 {
     char aFName[1024];
     sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
@@ -1530,7 +1517,6 @@ MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConverged
 
     string label;
     inFile >> label >> iter;
-    inFile >> label >> randseed;
     inFile >> label >> notConvergedVal;
     inFile.close();
 
@@ -1551,7 +1537,7 @@ MetaLearner::writePLLScore()
 	INTDBLMAP* plls = currPLL;
 
 	// Force maximum double precision to prevent truncation
-    outFile << std::setprecision(std::numeric_limits<double>::max_digits10); // new
+    outFile << std::setprecision(std::numeric_limits<double>::max_digits10);
 
     for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
     {

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -85,6 +85,7 @@ MetaLearner::setPriorGraph_All(const char* aFName)
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior config file path incorrect or file cannot be opened: " << aFName << std::endl;
+		exit(-1);
     }
 
 	char buffer[1024];
@@ -215,6 +216,7 @@ MetaLearner::setPriorGraph(const char* aFName, map<string,map<string,double>*>& 
     if (!inFile.is_open())
     {
         std::cerr << "Error: Prior file path incorrect or file cannot be opened: " << aFName << std::endl;
+		exit(-1);
     }
 
 	char buffer[1024];
@@ -525,7 +527,7 @@ MetaLearner::start(int f)
 	}
 	else
 	{
-		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree
+		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree ONLY IF some initial modules contain >=5 genes. Otherwise they begin empty 
 
 		for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
 		{
@@ -1104,6 +1106,24 @@ MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter ar
 int
 MetaLearner::initPhysicalDegree()
 {
+	// Early exit: no module can pass hit>4, so entire function is a no-op
+    bool anyLargeModule = false;
+    for (auto& m : moduleGeneSet) {
+        if (m.second->size() > 4) {
+            anyLargeModule = true;
+            break;
+        }
+    }
+    if (!anyLargeModule) {
+        cout << "Skipping initPhysicalDegree: all modules have <=4 genes (hit>4 can never be satisfied)" << endl;
+        return 0;
+    }
+	// if (moduleGeneSet.size() == geneModuleID.size()) // Early exit only for all singleton modules
+	// {
+	// 	cout << "Skipping initPhysicalDegree: singleton modules" << endl;
+	// 	return 0;
+	// }
+
 	for(map<int,map<string,int>*>::iterator mIter=moduleGeneSet.begin();mIter!=moduleGeneSet.end();mIter++)
 	{
 		map<string,int>* indegree=NULL;
@@ -1170,6 +1190,7 @@ MetaLearner::initPhysicalDegree()
 			}
 		}
 	}
+
 	return 0;
 }
 

--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -5,6 +5,8 @@
 #include <sys/timeb.h>
 #include <sys/time.h>
 #include <time.h>
+#include <iomanip> // new
+#include <limits> // new
 
 #include "Error.H"
 #include "Variable.H"
@@ -26,6 +28,7 @@
 
 MetaLearner::MetaLearner()
 {
+	shouldLoad = false; //********
 	restrictedFName[0]='\0';
 	preRandomizeSplit=false;
 	random=false;
@@ -39,6 +42,13 @@ MetaLearner::MetaLearner()
 
 MetaLearner::~MetaLearner()
 {
+}
+
+int
+MetaLearner::setShouldLoad(bool shouldLoadVal) //********
+{
+	shouldLoad = shouldLoadVal;
+	return 0;
 }
 
 int
@@ -303,6 +313,7 @@ MetaLearner::readModuleMembership(const char* aFName)
 		geneModuleID[geneName]=moduleID;
 	}
 	inFile.close();
+	
 	return 0;
 }
 
@@ -477,26 +488,46 @@ MetaLearner::start(int f)
 	currFold=f;
 	sprintf(foldoutDirName,"%s/fold%d",outputDirName,f);
 	int maxNumRegs = maxFactorSizeApprox-1; // max num of regulators a gene can have
-	rnd=gsl_rng_alloc(gsl_rng_default);
+
+	int iter = 0;
 	int rseed=getpid();
+	bool notConverged=true;
+	if(shouldLoad)
+	{
+		readCheckpointMetadata(iter, rseed, notConverged);
+		iter++;
+	}
+	rnd=gsl_rng_alloc(gsl_rng_default);
 	gsl_rng_set(rnd,rseed);
 	cout << "Random seed: " << rseed << endl;
-	initEdgePriorMeta_All();
-	initEdgeSet();
-	initPhysicalDegree();
+
+	initEdgePriorMeta_All(); // populates edgepriormap
+	initEdgeSet(); // populates edgeMap, edgePresenceProb (unused), varNeighborhoodPrior, potentials
 
 	VSET& varSet=varManager->getVariableSet();
-
-	for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
+	double currGlobalScore=0;
+	if (shouldLoad) //********
 	{
-		Variable *var = vIter->second;
-		variableStatus[var->getName()] = 0;
+		cout << "Read modules..." << endl;
+		readCheckpointModuleMembership(); // overwrites moduleGeneSet, geneModuleID (set by readModuleMembership)
+
+		cout << "Read networks..." << endl;
+		populateGraphsFromFile(maxFactorSizeApprox); // populates moduleIndegree, regulatorModuleOutdegree; updates edgeMap; overwrites potentials
+
+		currGlobalScore = loadInitPLLScore(); 
+		loadLastUpdate(); // populates variableStatus
+	}
+	else
+	{
+		initPhysicalDegree(); // populates moduleIndegree and regulatorModuleOutdegree
+
+		for (VSET_ITER vIter=varSet.begin(); vIter != varSet.end(); vIter++)
+		{
+			variableStatus[vIter->second->getName()] = 0;
+		}
+		currGlobalScore = getInitPLLScore();
 	}
 
-	double currGlobalScore=getInitPLLScore();
-
-	int iter=0;
-	bool notConverged=true;
 	while(notConverged && iter<50)
 	{
 		cout << "Beginning regulator identification of iter " << iter << endl;
@@ -540,9 +571,16 @@ MetaLearner::start(int f)
 			cout << "   Network not converged; score improvement of " << (currGlobalScore-scorePremodule) << ". Redefining modules." << endl;
 			redefineModules();
 		}
-		iter++;
+
 		scorePremodule=currGlobalScore;
-		dumpAllGraphs(maxNumRegs,f,iter);
+		dumpAllGraphs(maxFactorSizeApprox,f);
+
+		writeCheckpointMetadata(iter, rseed, notConverged); //********
+		writePLLScore(); //********
+		writeLastUpdate(); //********
+		doTar(); //********
+
+		iter++;
 	}
 
 	cout <<"Final Score " << currGlobalScore << endl;
@@ -645,7 +683,7 @@ MetaLearner::initEdgeSet()
 			{
 				initPrior=1-1e-6;
 			}
-			edgePresenceProb[edgeKey]=initPrior;
+			edgePresenceProb[edgeKey]=initPrior; // this is never used...
 			if(varNeighborhoodPrior.find(vIter->first)==varNeighborhoodPrior.end())
 			{
 				varNeighborhoodPrior[vIter->first]=log(1-initPrior);
@@ -1046,11 +1084,11 @@ MetaLearner::makeMove(MetaMove* nextMove, int currIteration)
 }
 
 int
-MetaLearner::dumpAllGraphs(int maxNumRegs,int foldid,int iter)
+MetaLearner::dumpAllGraphs(int maxFactorSizeApprox,int foldid) // remove iter argument
 {
 	VSET& varSet=varManager->getVariableSet();
 	char aFName[1024];
-	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxNumRegs+1);
+	sprintf(aFName,"%s/prediction_k%d.txt",foldoutDirName,maxFactorSizeApprox);
 	ofstream oFile(aFName);
 	factorGraph->dumpVarMB(oFile,varSet);
 	oFile.close();
@@ -1336,8 +1374,8 @@ MetaLearner::redefineModules()
 	}
 	modFile.close();
 
-	// For any genes with no neighbors, create single gene modules
-	cout << "   Number of singleton modules: " << genesWithNoNeighbors.size() << endl;
+	// For any genes with no neighbors, create single-gene modules
+	cout << "   Number of parentless genes: " << genesWithNoNeighbors.size() << endl;
 	for(map<string,int>::iterator gIter=genesWithNoNeighbors.begin();gIter!=genesWithNoNeighbors.end();gIter++)
 	{
 		largestModuleID++;
@@ -1431,4 +1469,416 @@ MetaLearner::initCorrelationDistances()
 			correlationDistances->setValue(cc, j, i);
 		}
 	}
+}
+
+
+// ******** checkpointing additions
+
+int
+MetaLearner::writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal)
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
+
+    ofstream outFile(aFName);
+    outFile << "iter " << iter << endl;
+    outFile << "randseed " << randseed << endl;
+    outFile << "notConverged " << notConvergedVal << endl;
+    outFile.close();
+
+    return 0;
+}
+
+int
+MetaLearner::readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal)
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/checkpoint.txt", foldoutDirName);
+
+    ifstream inFile(aFName);
+
+    string label;
+    inFile >> label >> iter;
+    inFile >> label >> randseed;
+    inFile >> label >> notConvergedVal;
+
+    inFile.close();
+
+    return 0;
+}
+
+int 
+MetaLearner::writePLLScore()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/pll.txt", foldoutDirName);
+    ofstream outFile(aFName);
+    VSET& varSet = varManager->getVariableSet();
+	if (currPLL == NULL)
+	{
+		return -1;
+	}
+	INTDBLMAP* plls = currPLL;
+
+	// Force maximum double precision to prevent truncation
+    outFile << std::setprecision(std::numeric_limits<double>::max_digits10); // new
+
+    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* var = varSet[vIter->first];
+        if (geneModuleID.find(var->getName()) == geneModuleID.end())
+            continue;
+        outFile << var->getName() << "\t" << (*plls)[vIter->first] << endl;
+    }
+    outFile.close();
+    return 0;
+}
+
+double 
+MetaLearner::loadInitPLLScore()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/pll.txt", foldoutDirName);
+    ifstream inFile(aFName);
+    char buffer[1024];
+
+    VSET& varSet = varManager->getVariableSet();
+    INTDBLMAP* plls = new INTDBLMAP;
+	if (currPLL != NULL)
+	{
+		delete currPLL;
+	}
+	currPLL = plls;
+
+    double initScore = 0;
+
+    while (inFile.good())
+    {
+        inFile.getline(buffer, 1023);
+        if (strlen(buffer) <= 0) 
+		{
+			continue;
+		}
+        char* tok = strtok(buffer, "\t");
+        int tokCnt = 0;
+        Variable* v = NULL;
+        double val = 0;
+        while (tok != NULL)
+        {
+            if (tokCnt == 0) 
+			{ 
+				int vid = varManager->getVarID(tok); 
+				v = varSet[vid]; 
+			}
+            else 
+			{ 
+				val = atof(tok); 
+			}
+            tok = strtok(NULL, "\t");
+            tokCnt++;
+        }
+        (*plls)[v->getID()] = val;
+        initScore += val;
+    }
+    return initScore;
+}
+
+int 
+MetaLearner::writeLastUpdate()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+    ofstream outFile(aFName);
+    VSET& varSet = varManager->getVariableSet();
+    for (VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* var = varSet[vIter->first];
+        if (geneModuleID.find(var->getName()) == geneModuleID.end())
+		{
+            continue;
+		}
+        outFile << var->getName() << "\t" << variableStatus[var->getName()] << endl;
+    }
+    outFile.close();
+    return 0;
+}
+
+int 
+MetaLearner::loadLastUpdate()
+{
+    char aFName[1024];
+    sprintf(aFName, "%s/lastUpdate.txt", foldoutDirName);
+    ifstream inFile(aFName);
+    char buffer[1024];
+    VSET& varSet = varManager->getVariableSet();
+    while (inFile.good())
+    {
+        inFile.getline(buffer, 1023);
+        if (strlen(buffer) <= 0) 
+		{
+			continue;
+		}
+        char* tok = strtok(buffer, "\t");
+        int tokCnt = 0;
+        Variable* v = NULL;
+        int titer = 0;
+        while (tok != NULL)
+        {
+            if (tokCnt == 0) 
+			{ 
+				int vid = varManager->getVarID(tok); 
+				v = varSet[vid]; 
+			}
+            else 
+			{ 
+				titer = atoi(tok); 
+			}
+            tok = strtok(NULL, "\t");
+            tokCnt++;
+        }
+        variableStatus[v->getName()] = titer;
+    }
+    return 0;
+}
+
+int 
+MetaLearner::doTar()
+{
+    char tarCmd[1024];
+    sprintf(tarCmd, "tar czf %s.tar.gz %s", foldoutDirName, foldoutDirName);
+    system(tarCmd);
+    return 0;
+}
+
+int
+MetaLearner::readCheckpointModuleMembership()
+{
+	// Clear previous degree distributions
+	moduleGeneSet.clear(); 
+	geneModuleID.clear();
+
+	char aFName[1024];
+    sprintf(aFName, "%s/modules.txt", foldoutDirName);
+	ifstream inFile(aFName);
+	if (!inFile.is_open())
+	{
+		std::cerr << "Error: could not open checkpoint module file: " << aFName << std::endl;
+		return -1;
+	}
+	
+    char buffer[1024];
+    int largestModuleID = -1;
+
+    // Read clustered modules from modules.txt
+    while(inFile.good())
+    {
+        inFile.getline(buffer,1023);
+        if(strlen(buffer)<=0)
+        {
+            continue;
+        }
+
+        string geneName;
+        int moduleID = -1;
+
+        int tokCnt = 0;
+        char* tok = strtok(buffer,"\t");
+        while(tok != NULL)
+        {
+            if(tokCnt == 0)
+            {
+                geneName.append(tok);
+            }
+            else if(tokCnt == 1)
+            {
+                moduleID = atoi(tok);
+            }
+            tok = strtok(NULL,"\t");
+            tokCnt++;
+        }
+        if(moduleID > largestModuleID)
+        {
+            largestModuleID = moduleID;
+        }
+
+        map<string,int>* geneSet = NULL;
+        if(moduleGeneSet.find(moduleID) == moduleGeneSet.end())
+        {
+            geneSet = new map<string,int>;
+            moduleGeneSet[moduleID] = geneSet;
+        }
+        else
+        {
+            geneSet = moduleGeneSet[moduleID];
+        }
+        (*geneSet)[geneName] = 0;
+        geneModuleID[geneName] = moduleID;
+    }
+    inFile.close();
+
+    // Recreate singleton modules (for parentless genes) that were not written to modules.txt
+    VSET& varSet = varManager->getVariableSet();
+    int genesWithNoNeighborsCount = 0;
+    for(VSET_ITER vIter = varSet.begin(); vIter != varSet.end(); vIter++)
+    {
+        Variable* v = vIter->second;
+        string geneName = v->getName();
+        if(geneModuleID.find(geneName) != geneModuleID.end())
+        {
+            continue;
+        }
+        largestModuleID++;
+        map<string,int>* newModule = new map<string,int>;
+        (*newModule)[geneName] = 0;
+        moduleGeneSet[largestModuleID] = newModule;
+        geneModuleID[geneName] = largestModuleID;
+        genesWithNoNeighborsCount++;
+    }
+    cout << "Recovered " << genesWithNoNeighborsCount << " parentless genes not present in modules.txt" << endl;
+    cout << "Total modules after recovery: " << moduleGeneSet.size() << endl;
+    return 0;
+}
+
+
+int
+MetaLearner::populateGraphsFromFile(int maxFactorSizeApprox)
+{
+	// Clear previous degree distributions
+	moduleIndegree.clear();
+	regulatorModuleOutdegree.clear();
+	//edgeMap.clear(); we want to keep the initialized edges, and only set them to 1 if we see them.
+
+	char aFName[1024];
+    sprintf(aFName, "%s/prediction_k%d.txt", foldoutDirName, maxFactorSizeApprox);
+	ifstream inFile(aFName);
+	if (!inFile.is_open())
+	{
+		std::cerr << "Error: could not open checkpoint graph file: " << aFName << std::endl;
+		return -1;
+	}
+	
+	char buffer[1024];
+	VSET& varSet=varManager->getVariableSet();
+
+	// Parse edges and track degrees
+	while(inFile.good())
+	{	
+		inFile.getline(buffer,1023);
+		if(strlen(buffer)<=0)
+		{
+			continue;
+		}
+		char* tok=strtok(buffer,"\t");
+		int tokCnt=0;
+		Variable* u=NULL; // source variable
+		Variable* v=NULL; // target variable
+		while(tok!=NULL)
+		{
+			if(tokCnt==0) // source node
+			{
+				int vid=varManager->getVarID(tok);
+				if (vid < 0)
+				{
+					break;
+				}
+				u=varSet[vid];
+			}
+			else if(tokCnt==1) // target node
+			{
+				int vid=varManager->getVarID(tok);
+				if (vid < 0)
+				{
+					break;
+				}
+				v=varSet[vid];
+			}
+			tok=strtok(NULL,"\t");
+			tokCnt++;
+		}
+		if (u == NULL || v == NULL)
+		{
+			continue;
+		}
+
+		// Track in-degree counts for the module containing the destination variable 'v'
+		int mID=geneModuleID[v->getName()];
+		map<string,int>* currIndegree=NULL;
+		if(moduleIndegree.find(mID)==moduleIndegree.end())
+		{
+			currIndegree=new map<string,int>;
+			moduleIndegree[mID]=currIndegree;
+		}
+		else
+		{
+			currIndegree=moduleIndegree[mID];
+		}
+
+		// Increment in-degree for source 'u' pointing into module 'mID'
+		if(currIndegree->find(u->getName())==currIndegree->end())
+		{
+			(*currIndegree)[u->getName()]=1;
+		}
+		else
+		{	
+			(*currIndegree)[u->getName()]=(*currIndegree)[u->getName()]+1;
+		}
+
+		// Track overall out-degree count for the regulator variable 'u'
+		if(regulatorModuleOutdegree.find(u->getName())==regulatorModuleOutdegree.end())
+		{
+			regulatorModuleOutdegree[u->getName()]=1;
+		}
+		else
+		{
+			regulatorModuleOutdegree[u->getName()]=regulatorModuleOutdegree[u->getName()]+1;
+		}
+
+		// Update the Factor Graph: Add source to target gene's Markov Blanket
+		SlimFactor* sFactor=factorGraph->getFactorAt(u->getID());
+		SlimFactor* dFactor=factorGraph->getFactorAt(v->getID());
+		dFactor->mergedMB[sFactor->fId]=0;
+
+		// Record the unique edge path string in the global edge map
+		string edgeKey;
+		edgeKey.append(u->getName().c_str());
+		edgeKey.append("\t");
+		edgeKey.append(v->getName().c_str());
+		edgeMap[edgeKey]=1;
+	}
+
+	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
+	for(int f=0;f<factorGraph->getFactorCnt();f++)
+	{
+		SlimFactor* sFactor=factorGraph->getFactorAt(f);
+
+		// Safely clear old potential objects to prevent memory leaks
+		if (sFactor->potFunc != NULL)
+		{
+			delete sFactor->potFunc;
+			sFactor->potFunc = NULL;
+		}
+		if (sFactor->mergedMB.size() == 0)
+		{
+			sFactor->potFunc = potManager->createPotential(sFactor->fId);
+			continue;
+		}
+
+		vector<int> parentIDs;
+		for(INTINTMAP_ITER mIter=sFactor->mergedMB.begin();mIter!=sFactor->mergedMB.end();mIter++)
+		{
+			parentIDs.push_back(mIter->first);
+		}
+
+		Potential* restoredPot = NULL;
+		potManager->computeLL(sFactor->fId, parentIDs, evidenceManager->getTrainingSet().size(), &restoredPot);
+		if (restoredPot == NULL)
+		{
+			sFactor->potFunc = potManager->createPotential(sFactor->fId);
+			continue;
+		}
+		sFactor->potFunc = restoredPot;
+	}
+
+	inFile.close();
+	return 0;
 }

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -49,7 +49,7 @@ class MetaLearner
 	// ******** checkpointing additions
 	bool shouldLoad; //********
 	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
-	int readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
+	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
 	int writePLLScore(); //********
 	double loadInitPLLScore(); //********
 	int writeLastUpdate(); //********

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,23 +23,23 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
-	int setShouldLoad(bool shouldLoadVal); // checkpointing
-	int setMaxFactorSize_Approx(int);
-	int setBeta1(double aval);
-	int setBeta_Motif(double bval);
+	void setShouldLoadCheckpoint(bool shouldLoadCheckpointVal);
+	void setMaxFactorSize_Approx(int);
+	void setBeta1(double aval);
+	void setBeta_Motif(double bval);
 	int setLambda(double bval);
-	int setConvergenceThreshold(double);
-	int setRestrictedList(const char*);
-	int setPreRandomizeSplit();
+	void setConvergenceThreshold(double);
+	void setRestrictedList(const char*);
+	void setPreRandomizeSplit();
 	int initEdgePriorMeta(const string& priorName, map<string,map<string,double>*>& graph, map<int,INTDBLMAP*>& edgePrior);
 	int doCrossValidation(int);
-	int setGlobalEvidenceManager(EvidenceManager*);
-	int setVariableManager(VariableManager*);
-	int setOutputDirName(const char*);
-	int setClusteringThreshold(double);
-	int setSpecificFold(int);
+	void setGlobalEvidenceManager(EvidenceManager*);
+	void setVariableManager(VariableManager*);
+	void setOutputDirName(const char*);
+	void setClusteringThreshold(double);
+	void setSpecificFold(int);
 	int getPredictionError_CrossValid(int);
-	int setRandom(bool);
+	void setRandom(bool);
 	int readModuleMembership(const char*);
 	int setDefaultModuleMembership();
 	int setPriorGraph_All(const char*);
@@ -47,9 +47,9 @@ class MetaLearner
 	private:
 
 	// checkpointing additions
-	bool shouldLoad; 
-	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); 
-	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); 
+	bool shouldLoadCheckpoint; 
+	int writeCheckpointMetadata(int iter, bool notConvergedVal); 
+	bool readCheckpointMetadata(int& iter, bool& notConvergedVal); 
 	int writePLLScore(); 
 	double loadInitPLLScore(); 
 	int writeLastUpdate(); 
@@ -75,7 +75,7 @@ class MetaLearner
 	void makeMove(MetaMove* move, int currIteration);
 	void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
 
-	int dumpAllGraphs(int,int); // remove iter argument
+	int dumpAllGraphs(int,int);
 
 	int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
 	int redefineModules();

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,7 +23,7 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
-	int setShouldLoad(bool shouldLoadVal); //********
+	int setShouldLoad(bool shouldLoadVal); // checkpointing
 	int setMaxFactorSize_Approx(int);
 	int setBeta1(double aval);
 	int setBeta_Motif(double bval);
@@ -46,17 +46,17 @@ class MetaLearner
 
 	private:
 
-	// ******** checkpointing additions
-	bool shouldLoad; //********
-	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
-	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
-	int writePLLScore(); //********
-	double loadInitPLLScore(); //********
-	int writeLastUpdate(); //********
-	int loadLastUpdate(); //********
-	int doTar(); //********
-	int readCheckpointModuleMembership(); //********
-	int populateGraphsFromFile(int maxFactorSizeApprox); //********
+	// checkpointing additions
+	bool shouldLoad; 
+	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); 
+	bool readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); 
+	int writePLLScore(); 
+	double loadInitPLLScore(); 
+	int writeLastUpdate(); 
+	int loadLastUpdate(); 
+	int doTar(); 
+	int readCheckpointModuleMembership(); 
+	int populateGraphsFromFile(int maxFactorSizeApprox); 
 
 	int start(int);
 	int initEdgePriorMeta_All();

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -23,6 +23,7 @@ class MetaLearner
 	public:
 	MetaLearner();
 	~MetaLearner();
+	int setShouldLoad(bool shouldLoadVal); //********
 	int setMaxFactorSize_Approx(int);
 	int setBeta1(double aval);
 	int setBeta_Motif(double bval);
@@ -44,6 +45,19 @@ class MetaLearner
 	int setPriorGraph_All(const char*);
 
 	private:
+
+	// ******** checkpointing additions
+	bool shouldLoad; //********
+	int writeCheckpointMetadata(int iter, int randseed, bool notConvergedVal); //********
+	int readCheckpointMetadata(int& iter, int& randseed, bool& notConvergedVal); //********
+	int writePLLScore(); //********
+	double loadInitPLLScore(); //********
+	int writeLastUpdate(); //********
+	int loadLastUpdate(); //********
+	int doTar(); //********
+	int readCheckpointModuleMembership(); //********
+	int populateGraphsFromFile(int maxFactorSizeApprox); //********
+
 	int start(int);
 	int initEdgePriorMeta_All();
 	map <string,double> betamap;
@@ -61,7 +75,7 @@ class MetaLearner
 	void makeMove(MetaMove* move, int currIteration);
 	void getNewPLLScore(Variable* u, Variable* v, vector<int>& parentIDs, string& edgeKey, double& mbScore, double& scoreImprovement, Potential**);
 
-	int dumpAllGraphs(int,int,int);
+	int dumpAllGraphs(int,int); // remove iter argument
 
 	int setPriorGraph(const char* aFName, map<string,map<string,double>*>& priorGraph);
 	int redefineModules();

--- a/common/SlimFactor.C
+++ b/common/SlimFactor.C
@@ -5,6 +5,11 @@
 
 SlimFactor::SlimFactor()
 {
+	vIds=NULL;
+	vCnt=0;
+	fId=-1;
+	canonicalParams=NULL;
+	potFunc=NULL;
 	refCnt=0;
 }
 
@@ -15,6 +20,8 @@ SlimFactor::SlimFactor(int fSize)
 	//secondPId=-1;
 	//confidence=0;
 	fId=-1;
+	canonicalParams=NULL;
+	potFunc=NULL;
 	refCnt=0;
 }
 


### PR DESCRIPTION
This PR introduces checkpointing support, allowing interrupted MERLIN-P runs to resume from where they left off. The implementation loosely follows the checkpointing structure used in the lab's previous version of MERLIN-P:
https://github.com/Roy-lab/merlin-p_self_checkpoint/tree/SR_branch
A new -a flag has been added to enable checkpoint loading. When this flag is specified, the program looks for checkpoint.txt in the output directory and loads:

- the current iteration,
- the random seed, and
- whether the current fold has already converged.

If checkpoint information is found, the program additionally loads:

- modules.txt to restore module information,
- prediction_k<maxFactorSizeApprox>.txt to restore indegrees, outdegrees, and potentials,
- pll.txt to restore the current network score, and
- lastUpdate.txt to restore the gene status (the iteration in which each gene last had a parent added).

If the -a flag is provided but no checkpoint files are present, the program starts from scratch and proceeds as usual.
