### PR TITLE
Rebuild sharedParents after loading checkpoint

### DIFF
--- a/MetaLearner.C
+++ b/MetaLearner.C
@@ -672,6 +672,18 @@ MetaLearner::restoreCheckpointGraph(const vector<pair<string, string>>& checkpoi
 		targetFactor->mergedMB[regID] = 0;
 
 		edgeMap[regID][targetID] = 1;
+
+		updatedThisIteration.insert(targetID);
+	}
+
+	// Track which targets share parents after restoring edges.
+	for (auto iter = edgeMap.begin(); iter != edgeMap.end(); iter++) {
+		unordered_map<int, int>& targets = iter->second;
+		for (auto targetIterA = targets.begin(); targetIterA != targets.end(); targetIterA++) {
+			for (auto targetIterB = targets.begin(); targetIterB != targets.end(); targetIterB++) {
+				sharedParents[targetIterA->first][targetIterB->first] = 1;
+			}
+		}
 	}
 
 	// Re-initialize potentials: iterate through all factors to rebuild potential distributions using the restored edges
@@ -1153,7 +1165,7 @@ MetaLearner::makeMove(MetaMove& nextMove, int currIteration)
 
 	variableStatus[v->getName()] = currIteration;
 
-	updatedThisIteration.push_back(v->getID());
+	updatedThisIteration.insert(v->getID());
 
 	// Mark all other targets of u as sharing a parent with v.
 	unordered_map<int, int> otherTargets = edgeMap[u->getID()];
@@ -1536,18 +1548,17 @@ MetaLearner::updateSharedParentDistances()
 	unordered_map<int, Variable*>& varSet = varManager->getVariableSet();
 	int varCount = varSet.size();
 
-	int updateCount = 0;
-
-	sort(updatedThisIteration.begin(), updatedThisIteration.end());
+	vector<int> sortedTargetIDs(updatedThisIteration.begin(), updatedThisIteration.end());
+	sort(sortedTargetIDs.begin(), sortedTargetIDs.end());
 
 	vector<bool> willVisit(varCount, false);
-	for (int k = 0; k < updatedThisIteration.size(); k++) {
-		willVisit[updatedThisIteration[k]] = true;
+	for (int k = 0; k < sortedTargetIDs.size(); k++) {
+		willVisit[sortedTargetIDs[k]] = true;
 	}
 
 	vector<double> denoms(varCount, 0);
 
-	for (auto iter = updatedThisIteration.begin(); iter != updatedThisIteration.end(); iter++) {
+	for (auto iter = sortedTargetIDs.begin(); iter != sortedTargetIDs.end(); iter++) {
 		int varID = *iter;
 		SlimFactor* factorA = factorGraph->getFactorAt(varID);
 		vector<pair<int, double>>& weightsA = factorA->potFunc->getWeights();
@@ -1572,8 +1583,6 @@ MetaLearner::updateSharedParentDistances()
 			if (willVisit[siblingID] && siblingID < varID) {
 				continue;
 			}
-
-			updateCount += 1;
 
 			SlimFactor* factorB = factorGraph->getFactorAt(siblingID);
 			vector<pair<int, double>>& weightsB = factorB->potFunc->getWeights();

--- a/MetaLearner.H
+++ b/MetaLearner.H
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include "CommonTypes.H"
 #include "HierarchicalCluster.H"
 
@@ -106,6 +107,6 @@ class MetaLearner
 		unordered_map<int, unordered_map<int, int>> sharedParents;
 
 		// Var ids of any nodes with a parent added this iteration.
-		vector<int> updatedThisIteration;
+		unordered_set<int> updatedThisIteration;
 };
 #endif


### PR DESCRIPTION
@sroyyors This PR is a follow-up to https://github.com/Roy-lab/merlin-p/pull/7, which fixes a small incompatibility between @livj4711's checkpointing work and the performance changes I applied. 

As part of #7 we now track which targets share parents, because this info helps determine which cached distances need to be refreshed during the module assignment step. That shared parent matrix needs to be rebuilt when loading from a checkpoint, in order to ensure the distances are refreshed. This PR adds a step to the checkpoint loading flow to reconstruct that matrix using the edges saved in the checkpoint.